### PR TITLE
Drop schema template when cleaning up (for iotdb1.1)

### DIFF
--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBClusterSession.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBClusterSession.java
@@ -407,4 +407,23 @@ public class IoTDBClusterSession extends IoTDBSessionBase {
     }
     this.service.shutdown();
   }
+
+  @Override
+  public void cleanup() {
+    try {
+      sessionPool.executeNonQueryStatement("drop database root." + config.getDbConfig().getDB_NAME() + ".**");
+    } catch (IoTDBConnectionException e) {
+      LOGGER.error("Failed to connect to IoTDB:" + e.getMessage());
+    } catch (StatementExecutionException e) {
+      LOGGER.error("Failed to execute statement:" + e.getMessage());
+    }
+
+    try {
+      sessionPool.executeNonQueryStatement("drop schema template " + config.getTEMPLATE_NAME());
+    } catch (IoTDBConnectionException e) {
+      LOGGER.error("Failed to connect to IoTDB:" + e.getMessage());
+    } catch (StatementExecutionException e) {
+      LOGGER.error("Failed to execute statement:" + e.getMessage());
+    }
+  }
 }

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSession.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSession.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -378,7 +379,22 @@ public class IoTDBSession extends IoTDBSessionBase {
   @Override
   public void cleanup() {
     try {
+
+//      List<String> templates = session.showAllTemplates();
+//      System.out.println(templates);
+      // DEACTIVATE schema template BenchmarkTemplate from root.**
+//      for (String template : templates) {
+      session.executeNonQueryStatement("deactivate schema template " + config.getTEMPLATE_NAME() + " from root." + config.getDbConfig().getDB_NAME() + ".**");
+      LOGGER.info("1");
+//      session.executeNonQueryStatement("unset schema template " + config.getTEMPLATE_NAME() + " from root." + config.getDbConfig().getDB_NAME() + ".**");
+//      LOGGER.info("2");
+      session.executeNonQueryStatement("drop schema template " + config.getTEMPLATE_NAME());
+      LOGGER.info("3");
+//      LOGGER.info("Schema template ");
       session.executeNonQueryStatement(DELETE_SERIES_SQL);
+//      }
+//      session.deleteDatabase();
+//      session.deactivateTemplateOn();
     } catch (IoTDBConnectionException e) {
       LOGGER.error("Failed to connect to IoTDB:" + e.getMessage());
     } catch (StatementExecutionException e) {

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSession.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSession.java
@@ -379,22 +379,15 @@ public class IoTDBSession extends IoTDBSessionBase {
   @Override
   public void cleanup() {
     try {
+      session.executeNonQueryStatement("drop database root." + config.getDbConfig().getDB_NAME() + ".**");
+    } catch (IoTDBConnectionException e) {
+      LOGGER.error("Failed to connect to IoTDB:" + e.getMessage());
+    } catch (StatementExecutionException e) {
+      LOGGER.error("Failed to execute statement:" + e.getMessage());
+    }
 
-//      List<String> templates = session.showAllTemplates();
-//      System.out.println(templates);
-      // DEACTIVATE schema template BenchmarkTemplate from root.**
-//      for (String template : templates) {
-      session.executeNonQueryStatement("deactivate schema template " + config.getTEMPLATE_NAME() + " from root." + config.getDbConfig().getDB_NAME() + ".**");
-      LOGGER.info("1");
-//      session.executeNonQueryStatement("unset schema template " + config.getTEMPLATE_NAME() + " from root." + config.getDbConfig().getDB_NAME() + ".**");
-//      LOGGER.info("2");
+    try {
       session.executeNonQueryStatement("drop schema template " + config.getTEMPLATE_NAME());
-      LOGGER.info("3");
-//      LOGGER.info("Schema template ");
-      session.executeNonQueryStatement(DELETE_SERIES_SQL);
-//      }
-//      session.deleteDatabase();
-//      session.deactivateTemplateOn();
     } catch (IoTDBConnectionException e) {
       LOGGER.error("Failed to connect to IoTDB:" + e.getMessage());
     } catch (StatementExecutionException e) {


### PR DESCRIPTION
When IS_DELETE_DATA=true, drop the template named "TEMPLATE_NAME" when cleaning up the data.