### PR TITLE
Fixed compilation issues caused by relying on a deleted snapshot version

### DIFF
--- a/iotdb-1.1/pom.xml
+++ b/iotdb-1.1/pom.xml
@@ -53,12 +53,12 @@
     <dependency>
       <groupId>org.apache.iotdb</groupId>
       <artifactId>iotdb-jdbc</artifactId>
-      <version>1.1.1-20230526.064734-1</version>
+      <version>1.1.1-Snapshot</version>
     </dependency>
     <dependency>
       <groupId>org.apache.iotdb</groupId>
       <artifactId>iotdb-session</artifactId>
-      <version>1.1.1-20230526.064734-1</version>
+      <version>1.1.1-Snapshot</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Before：
<img width="1503" alt="image" src="https://github.com/thulab/iot-benchmark/assets/32640567/720bb28f-0cc8-4eec-93b5-483e56ccc1af">
After：
<img width="846" alt="image" src="https://github.com/thulab/iot-benchmark/assets/32640567/c8fce62b-fcad-44c6-b047-dbc6c260bc30">
