### PR TITLE
Display information in git.properties

### DIFF
--- a/iotdb-1.1/src/assembly/assembly.xml
+++ b/iotdb-1.1/src/assembly/assembly.xml
@@ -67,5 +67,8 @@
         <file>
             <source>${maven.multiModuleProjectDirectory}/LICENSE</source>
         </file>
+        <file>
+            <source>${project.build.outputDirectory}/git.properties</source>
+        </file>
     </files>
 </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -101,12 +101,40 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>4.9.10</version>
+                    <executions>
+                        <execution>
+                            <id>get-the-git-infos</id>
+                            <goals>
+                                <goal>revision</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                        <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                        <includeOnlyProperties>
+                            <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.dirty$</includeOnlyProperty>
+                            <includeOnlyProperty>git.build.time</includeOnlyProperty>
+                        </includeOnlyProperties>
+                        <commitIdGenerationMode>full</commitIdGenerationMode>
+                        <dateFormat>yyyy-MM-dd_HH:mm:ss z</dateFormat>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Display some information in git.properties, including
```
#Generated by Git-Commit-Id-Plugin
git.build.time=2023-07-31_12\:25\:08  CST
git.commit.id.abbrev=ee53bf6
git.dirty=true
```
For iotdb1.1 only.