### PR TITLE
For MultiDeviceBatch, check IS_SENSOR_TS_ALIGNMENT in ConfigDescriptor

### DIFF
--- a/configuration/conf/README-cn.md
+++ b/configuration/conf/README-cn.md
@@ -17,5 +17,5 @@ DNW=1时，搭配效果应与加入跨设备Batch之前完全一致，**此处�
   - insert方式：SESSION_BY_RECORDS模式允许DNW>1，SESSION_BY_RECORD、SESSION_BY_TABLET模式只允许DNW=1，参数不匹配则报错"The combination of DEVICE_NUM_PER_WRITE and insert-mode is not supported"
 - 与BATCH_SIZE_PER_WRITE：BATCH_SIZE_PER_WRITE含义为单次向单个设备写入的行数，单次写入的总行数为DNW×BATCH_SIZE_PER_WRITE
 - 与IS_CLIENT_BIND：支持true与false
-- 与IS_SENSOR_TS_ALIGNMENT：暂不支持此配置项为false，但是不会报错，而是按true处理
+- 与IS_SENSOR_TS_ALIGNMENT：暂不支持此配置项为false
 

--- a/configuration/conf/README.md
+++ b/configuration/conf/README.md
@@ -19,4 +19,4 @@ So we only analyze the case where `DNW`>1.
   - Insert mode: `SESSION_BY_RECORDS` mode allows `DNW`>1, `SESSION_BY_RECORD` and `SESSION_BY_TABLET` modes only allow `DNW`=1, and an error will be reported if the parameters do not match("The combination of DEVICE_NUM_PER_WRITE and insert-mode is not supported").
 - With `BATCH_SIZE_PER_WRITE`: `BATCH_SIZE_PER_WRITE` refers to the number of rows written to a single device in a single write operation. The total number of rows written in a single operation is `DNW` × `BATCH_SIZE_PER_WRITE`.
 - With `IS_CLIENT_BIND`: True and false are both supported.
-- With `IS_SENSOR_TS_ALIGNMENT`: This configuration item is currently not supported as false, but there will be no error and it will be treated as true.
+- With `IS_SENSOR_TS_ALIGNMENT`: This configuration item is currently not supported as false.

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -595,6 +595,10 @@ public class ConfigDescriptor {
         result = false;
       }
     }
+    if (config.getDEVICE_NUM_PER_WRITE() != 1 && !config.isIS_SENSOR_TS_ALIGNMENT()) {
+      LOGGER.error("The combination of \"DEVICE_NUM_PER_WRITE > 1\" and \"IS_SENSOR_TS_ALIGNMENT == false\" is not supported");
+      result = false;
+    }
     return result;
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -596,7 +596,8 @@ public class ConfigDescriptor {
       }
     }
     if (config.getDEVICE_NUM_PER_WRITE() != 1 && !config.isIS_SENSOR_TS_ALIGNMENT()) {
-      LOGGER.error("The combination of \"DEVICE_NUM_PER_WRITE > 1\" and \"IS_SENSOR_TS_ALIGNMENT == false\" is not supported");
+      LOGGER.error(
+          "The combination of \"DEVICE_NUM_PER_WRITE > 1\" and \"IS_SENSOR_TS_ALIGNMENT == false\" is not supported");
       result = false;
     }
     return result;


### PR DESCRIPTION
The combination of "DEVICE_NUM_PER_WRITE > 1" and "IS_SENSOR_TS_ALIGNMENT == false" is not supported