### PR TITLE
Optimize IoTDB iterate way

### DIFF
--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/ISessionDataSet.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/ISessionDataSet.java
@@ -1,5 +1,6 @@
 package cn.edu.tsinghua.iot.benchmark.iotdb110;
 
+import org.apache.iotdb.isession.SessionDataSet;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.tsfile.read.common.RowRecord;
@@ -10,4 +11,6 @@ public interface ISessionDataSet {
   boolean hasNext() throws IoTDBConnectionException, StatementExecutionException;
 
   void close() throws IoTDBConnectionException, StatementExecutionException;
+
+  SessionDataSet.DataIterator iterator();
 }

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBClusterSession.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBClusterSession.java
@@ -19,6 +19,7 @@
 
 package cn.edu.tsinghua.iot.benchmark.iotdb110;
 
+import org.apache.iotdb.isession.SessionDataSet;
 import org.apache.iotdb.isession.pool.SessionDataSetWrapper;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
@@ -157,6 +158,11 @@ public class IoTDBClusterSession extends IoTDBSessionBase {
       @Override
       public void close() throws IoTDBConnectionException, StatementExecutionException {
         sessionDataSet.close();
+      }
+
+      @Override
+      public SessionDataSet.DataIterator iterator() {
+        return sessionDataSet.iterator();
       }
     }
   }

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSession.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSession.java
@@ -148,6 +148,11 @@ public class IoTDBSession extends IoTDBSessionBase {
       public void close() throws IoTDBConnectionException, StatementExecutionException {
         sessionDataSet.close();
       }
+
+      @Override
+      public SessionDataSet.DataIterator iterator() {
+        return sessionDataSet.iterator();
+      }
     }
   }
 

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSessionBase.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSessionBase.java
@@ -19,6 +19,7 @@
 
 package cn.edu.tsinghua.iot.benchmark.iotdb110;
 
+import org.apache.iotdb.isession.SessionDataSet;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -183,10 +184,10 @@ public class IoTDBSessionBase extends IoTDB {
               () -> {
                 try {
                   ISessionDataSet sessionDataSet = sessionWrapper.executeQueryStatement(executeSQL);
-                  while (sessionDataSet.hasNext()) {
-                    RowRecord rowRecord = sessionDataSet.next();
-                    line.getAndIncrement();
-                    if (config.isIS_COMPARISON()) {
+                  if (config.isIS_COMPARISON()) {
+                    while (sessionDataSet.hasNext()) {
+                      RowRecord rowRecord = sessionDataSet.next();
+                      line.getAndIncrement();
                       List<Object> record = new ArrayList<>();
                       switch (operation) {
                         case AGG_RANGE_QUERY:
@@ -211,7 +212,13 @@ public class IoTDBSessionBase extends IoTDB {
                       }
                       records.add(record);
                     }
+                  } else {
+                    SessionDataSet.DataIterator iterator = sessionDataSet.iterator();
+                    while (iterator.next()) {
+                      line.getAndIncrement();
+                    }
                   }
+
                   sessionDataSet.close();
                 } catch (StatementExecutionException | IoTDBConnectionException e) {
                   LOGGER.error("exception occurred when execute query={}", executeSQL, e);


### PR DESCRIPTION
For the case that we don't need to verify the correctness of the result, we should use DataIterator to iterate the ResultSet instead of using `SessionDataSet.next()` which will cause unnecessary overhead for constructing `RowRecord`, this may be nonnegligible while the result set is very large.