### PR TITLE
Support variable tag in benchmark

### DIFF
--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -146,7 +146,7 @@
 # 标签值前缀
 # TAG_VALUE_PREFIX=value_
 
-# 每个标签值的取值种数，使用逗号分开，设置个数应与标签名数量相等。例如TAG_NUMBER=2，TAG_VALUE_CARDINALITY=50,10，说明第一个标签名可能有50种值，第二个标签名可能有10种值
+# 每个标签值的取值种数，使用逗号分开，设置个数应与标签名数量相等。例如TAG_NUMBER=2，TAG_VALUE_CARDINALITY=50,10，说明第一个标签名可能有50种值，第二个标签名可能有10种值。d_0的中间路径将为value_0.value_0.d_0。
 # TAG_VALUE_CARDINALITY=
 
 ############## 被测系统为IoTDB时扩展参数 ##################

--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -143,6 +143,18 @@
 # 定义设备标签值，所有设备相同，使用逗号分开，目前支持iotdb-0.12, iotdb-0.13, influxdb-2.x, timescaledb, tdengine
 # DEVICE_TAGS=
 
+# 标签名数量
+# TAG_NUMBER_=3
+
+# 标签名前缀
+# TAG_KEY_PREFIX=tag_
+
+# 标签值前缀
+# TAG_VALUE_PREFIX=value_
+
+# 每个标签值的取值种数，使用逗号分开，设置个数应与标签名数量相等。例如TAG_NUMBER_=2，TAG_VALUE_RANGE=50,10，说明第一个标签名可能有50种值，第二个标签名可能有10种值。
+# TAG_VALUE_RANGE=50,50,10
+
 ############## 被测系统为IoTDB时扩展参数 ##################
 # 是否使用thrift压缩，需要在iotdb的配置文件iotdb-common.properties中设置rpc_thrift_compression_enable=true
 # ENABLE_THRIFT_COMPRESSION=false

--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -137,12 +137,6 @@
 # 传感器名称前缀
 # SENSOR_NAME_PREFIX=s_
 
-# 标签名的前缀
-# TAG_NAME_PREFIX=tag_
-
-# 定义设备标签值，所有设备相同，使用逗号分开，目前支持iotdb-0.12, iotdb-0.13, influxdb-2.x, timescaledb, tdengine
-# DEVICE_TAGS=
-
 # 标签名数量
 # TAG_NUMBER=0
 

--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -146,7 +146,7 @@
 # 标签值前缀
 # TAG_VALUE_PREFIX=value_
 
-# 每个标签值的取值种数，使用逗号分开，设置个数应与标签名数量相等。例如TAG_NUMBER=2，TAG_VALUE_CARDINALITY=50,10，说明第一个标签名可能有50种值，第二个标签名可能有10种值。d_0的中间路径将为value_0.value_0.d_0。
+# 每个标签值的取值种数，使用逗号分开，设置个数应与标签名数量相等。例如TAG_NUMBER=2，TAG_VALUE_CARDINALITY=50,10，说明第一个标签名可能有50种值，第二个标签名可能有10种值。d_0的中间路径将为value_0.value_0.d_0。该配置不影响总点数。
 # TAG_VALUE_CARDINALITY=
 
 ############## 被测系统为IoTDB时扩展参数 ##################

--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -144,7 +144,7 @@
 # DEVICE_TAGS=
 
 # 标签名数量
-# TAG_NUMBER_=3
+# TAG_NUMBER=0
 
 # 标签名前缀
 # TAG_KEY_PREFIX=tag_
@@ -152,8 +152,8 @@
 # 标签值前缀
 # TAG_VALUE_PREFIX=value_
 
-# 每个标签值的取值种数，使用逗号分开，设置个数应与标签名数量相等。例如TAG_NUMBER_=2，TAG_VALUE_RANGE=50,10，说明第一个标签名可能有50种值，第二个标签名可能有10种值。
-# TAG_VALUE_RANGE=50,50,10
+# 每个标签值的取值种数，使用逗号分开，设置个数应与标签名数量相等。例如TAG_NUMBER=2，TAG_VALUE_CARDINALITY=50,10，说明第一个标签名可能有50种值，第二个标签名可能有10种值
+# TAG_VALUE_CARDINALITY=
 
 ############## 被测系统为IoTDB时扩展参数 ##################
 # 是否使用thrift压缩，需要在iotdb的配置文件iotdb-common.properties中设置rpc_thrift_compression_enable=true

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
@@ -182,9 +182,11 @@ public class Config {
   /** name prefix of sensor */
   private String SENSOR_NAME_PREFIX = "s_";
   /** name prefix of tag */
-  private String TAG_NAME_PREFIX = "tag_";
-  /** The tags of device. Each device is same. */
-  private Map<String, String> DEVICE_TAGS = new LinkedHashMap<>();
+  private int TAG_NUMBER = 0;
+
+  private String TAG_KEY_PREFIX = "tag_";
+  private String TAG_VALUE_PREFIX = "value_";
+  private List<Integer> TAG_VALUE_CARDINALITY = new ArrayList<>();
 
   // 设备、传感器、客户端：生成数据的规律
   /** 线性 默认 9个 */
@@ -844,27 +846,41 @@ public class Config {
     this.CLIENT_NUMBER = CLIENT_NUMBER;
   }
 
-  public String getTAG_NAME_PREFIX() {
-    return TAG_NAME_PREFIX;
-  }
-
-  public void setTAG_NAME_PREFIX(String TAG_NAME_PREFIX) {
-    this.TAG_NAME_PREFIX = TAG_NAME_PREFIX;
-  }
-
   public Map<String, String> getDEVICE_TAGS() {
-    return new LinkedHashMap<>(DEVICE_TAGS);
+    // TODO: remove this
+    return null;
   }
 
-  public void setDEVICE_TAGS(String DEVICE_TAGS) {
-    if (DEVICE_TAGS.length() != 0) {
-      this.DEVICE_TAGS = new LinkedHashMap<>();
-      int tagIndex = 0;
-      for (String tagValue : DEVICE_TAGS.split(",")) {
-        this.DEVICE_TAGS.put(TAG_NAME_PREFIX + tagIndex, tagValue);
-        tagIndex++;
-      }
-    }
+  public int getTAG_NUMBER() {
+    return TAG_NUMBER;
+  }
+
+  public void setTAG_NUMBER(int TAG_NUMBER) {
+    this.TAG_NUMBER = TAG_NUMBER;
+  }
+
+  public String getTAG_KEY_PREFIX() {
+    return TAG_KEY_PREFIX;
+  }
+
+  public void setTAG_KEY_PREFIX(String TAG_KEY_PREFIX) {
+    this.TAG_KEY_PREFIX = TAG_KEY_PREFIX;
+  }
+
+  public String getTAG_VALUE_PREFIX() {
+    return TAG_VALUE_PREFIX;
+  }
+
+  public void setTAG_VALUE_PREFIX(String TAG_VALUE_PREFIX) {
+    this.TAG_VALUE_PREFIX = TAG_VALUE_PREFIX;
+  }
+
+  public List<Integer> getTAG_VALUE_CARDINALITY() {
+    return TAG_VALUE_CARDINALITY;
+  }
+
+  public void setTAG_VALUE_CARDINALITY(List<Integer> TAG_VALUE_CARDINALITY) {
+    this.TAG_VALUE_CARDINALITY = TAG_VALUE_CARDINALITY;
   }
 
   public String getGROUP_NAME_PREFIX() {
@@ -1785,8 +1801,11 @@ public class Config {
     configProperties.addProperty("Extern Param", "GROUP_NAME_PREFIX", this.GROUP_NAME_PREFIX);
     configProperties.addProperty("Extern Param", "DEVICE_NAME_PREFIX", this.DEVICE_NAME_PREFIX);
     configProperties.addProperty("Extern Param", "SENSOR_NAME_PREFIX", this.SENSOR_NAME_PREFIX);
-    configProperties.addProperty("Extern Param", "TAG_NAME_PREFIX", this.TAG_NAME_PREFIX);
-    configProperties.addProperty("Extern Param", "DEVICE_TAGS", this.DEVICE_TAGS);
+    configProperties.addProperty("Extern Param", "TAG_NUMBER", this.TAG_NUMBER);
+    configProperties.addProperty("Extern Param", "TAG_KEY_PREFIX", this.TAG_KEY_PREFIX);
+    configProperties.addProperty("Extern Param", "TAG_VALUE_PREFIX", this.TAG_VALUE_PREFIX);
+    configProperties.addProperty(
+        "Extern Param", "TAG_VALUE_CARDINALITY", this.TAG_VALUE_CARDINALITY);
 
     configProperties.addProperty(
         "Extern Param", "ENABLE_THRIFT_COMPRESSION", this.ENABLE_THRIFT_COMPRESSION);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
@@ -846,11 +846,6 @@ public class Config {
     this.CLIENT_NUMBER = CLIENT_NUMBER;
   }
 
-  public Map<String, String> getDEVICE_TAGS() {
-    // TODO: remove this
-    return null;
-  }
-
   public int getTAG_NUMBER() {
     return TAG_NUMBER;
   }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -33,6 +33,7 @@ import java.io.*;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static cn.edu.tsinghua.iot.benchmark.tsdb.enums.DBInsertMode.INSERT_USE_SESSION_RECORDS;
 
@@ -248,8 +249,21 @@ public class ConfigDescriptor {
             properties.getProperty("DEVICE_NAME_PREFIX", config.getDEVICE_NAME_PREFIX()));
         config.setSENSOR_NAME_PREFIX(
             properties.getProperty("SENSOR_NAME_PREFIX", config.getSENSOR_NAME_PREFIX()));
-        config.setDEVICE_TAGS(properties.getProperty("DEVICE_TAGS", ""));
-
+        config.setTAG_NUMBER(
+            Integer.parseInt(properties.getProperty("TAG_NUMBER", config.getTAG_NUMBER() + "")));
+        config.setTAG_KEY_PREFIX(
+            properties.getProperty("TAG_KEY_PREFIX", config.getTAG_KEY_PREFIX()));
+        config.setTAG_VALUE_PREFIX(
+            properties.getProperty("TAG_VALUE_PREFIX", config.getTAG_VALUE_PREFIX()));
+        config.setTAG_VALUE_CARDINALITY(
+            Arrays.stream(
+                    properties
+                        .getProperty(
+                            "TAG_VALUE_CARDINALITY", config.getTAG_VALUE_CARDINALITY() + "")
+                        .split(","))
+                .mapToInt(Integer::parseInt)
+                .boxed()
+                .collect(Collectors.toList()));
         config.setBENCHMARK_CLUSTER(
             Boolean.parseBoolean(
                 properties.getProperty("BENCHMARK_CLUSTER", config.isBENCHMARK_CLUSTER() + "")));
@@ -594,6 +608,15 @@ public class ConfigDescriptor {
     if (config.getDEVICE_NUM_PER_WRITE() != 1 && !config.isIS_SENSOR_TS_ALIGNMENT()) {
       LOGGER.error(
           "The combination of \"DEVICE_NUM_PER_WRITE > 1\" and \"IS_SENSOR_TS_ALIGNMENT == false\" is not supported");
+      result = false;
+    }
+    // check tag
+    if (config.getTAG_NUMBER() != config.getTAG_VALUE_CARDINALITY().size()) {
+      LOGGER.error(
+          "TAG_NUMBER must be equal to TAG_VALUE_CARDINALITY's size. Currently, "
+              + "TAG_NUMBER = {}, TAG_VALUE_CARDINALITY = {}.",
+          config.getTAG_NUMBER(),
+          config.getTAG_VALUE_CARDINALITY().size());
       result = false;
     }
     return result;

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -256,15 +256,18 @@ public class ConfigDescriptor {
         config.setTAG_VALUE_PREFIX(
             properties.getProperty("TAG_VALUE_PREFIX", config.getTAG_VALUE_PREFIX()));
         config.setTAG_VALUE_CARDINALITY(
-            Arrays.stream(
-                    properties
-                        .getProperty(
-                            "TAG_VALUE_CARDINALITY", config.getTAG_VALUE_CARDINALITY() + "")
-                        .split(","))
-                .filter(s -> !s.isEmpty())
-                .mapToInt(Integer::parseInt)
-                .boxed()
-                .collect(Collectors.toList()));
+                Arrays.stream(
+                                properties
+                                        .getProperty(
+                                                "TAG_VALUE_CARDINALITY",
+                                                config.getTAG_VALUE_CARDINALITY().stream()
+                                                        .map(Object::toString)
+                                                        .collect(Collectors.joining(",")))
+                                        .split(","))
+                        .filter(s -> !s.isEmpty())
+                        .mapToInt(Integer::parseInt)
+                        .boxed()
+                        .collect(Collectors.toList()));
         config.setBENCHMARK_CLUSTER(
             Boolean.parseBoolean(
                 properties.getProperty("BENCHMARK_CLUSTER", config.isBENCHMARK_CLUSTER() + "")));

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -261,6 +261,7 @@ public class ConfigDescriptor {
                         .getProperty(
                             "TAG_VALUE_CARDINALITY", config.getTAG_VALUE_CARDINALITY() + "")
                         .split(","))
+                .filter(s -> !s.isEmpty())
                 .mapToInt(Integer::parseInt)
                 .boxed()
                 .collect(Collectors.toList()));

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -256,18 +256,18 @@ public class ConfigDescriptor {
         config.setTAG_VALUE_PREFIX(
             properties.getProperty("TAG_VALUE_PREFIX", config.getTAG_VALUE_PREFIX()));
         config.setTAG_VALUE_CARDINALITY(
-                Arrays.stream(
-                                properties
-                                        .getProperty(
-                                                "TAG_VALUE_CARDINALITY",
-                                                config.getTAG_VALUE_CARDINALITY().stream()
-                                                        .map(Object::toString)
-                                                        .collect(Collectors.joining(",")))
-                                        .split(","))
-                        .filter(s -> !s.isEmpty())
-                        .mapToInt(Integer::parseInt)
-                        .boxed()
-                        .collect(Collectors.toList()));
+            Arrays.stream(
+                    properties
+                        .getProperty(
+                            "TAG_VALUE_CARDINALITY",
+                            config.getTAG_VALUE_CARDINALITY().stream()
+                                .map(Object::toString)
+                                .collect(Collectors.joining(",")))
+                        .split(","))
+                .filter(s -> !s.isEmpty())
+                .mapToInt(Integer::parseInt)
+                .boxed()
+                .collect(Collectors.toList()));
         config.setBENCHMARK_CLUSTER(
             Boolean.parseBoolean(
                 properties.getProperty("BENCHMARK_CLUSTER", config.isBENCHMARK_CLUSTER() + "")));

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
@@ -98,7 +98,7 @@ public class MetaUtil {
     }
     int id = deviceName.hashCode();
     Map<String, String> res = new HashMap<>();
-    for (int i = 0; i < LEVEL_CARDINALITY.length; i++) {
+    for (int i = 0; i < LEVEL_CARDINALITY.length - 1; i++) {
       id = id % LEVEL_CARDINALITY[i];
       int tagValueId = id / LEVEL_CARDINALITY[i + 1];
       res.put(TAG_KEY_PREFIX + i, TAG_VALUE_PREFIX + tagValueId);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
@@ -95,7 +95,8 @@ public class MetaUtil {
   }
 
   /**
-   * Get tags pair by deviceName.
+   * Get tags pair by deviceName. Tags are allocated based on hashCode to ensure an even number of
+   * devices under each tag as much as possible.
    *
    * @param deviceName deviceName
    * @return tags pair
@@ -115,7 +116,8 @@ public class MetaUtil {
   }
 
   /**
-   * Get tags pair by deviceId.
+   * Get tags pair by deviceId. Tags are allocated based on hashCode to ensure an even number of
+   * devices under each tag as much as possible.
    *
    * @param deviceId deviceId
    * @return tags pair

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
@@ -5,6 +5,7 @@ import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.conf.Constants;
 import cn.edu.tsinghua.iot.benchmark.exception.WorkloadException;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -17,15 +18,16 @@ public class MetaUtil {
   private static final String TAG_VALUE_PREFIX = config.getTAG_VALUE_PREFIX();
   private static final int TAG_NUMBER = config.getTAG_NUMBER();
   private static final List<Integer> TAG_VALUE_CARDINALITY = config.getTAG_VALUE_CARDINALITY();
-  private static final long[] LEVEL_CARDINALITY = new long[TAG_VALUE_CARDINALITY.size() + 1];
+  private static final List<Long> LEVEL_CARDINALITY =
+      Arrays.asList(new Long[TAG_VALUE_CARDINALITY.size() + 1]);
 
   static {
     int idx = TAG_VALUE_CARDINALITY.size();
     long sum = 1;
-    LEVEL_CARDINALITY[idx--] = 1;
+    LEVEL_CARDINALITY.set(idx--, 1L);
     for (; idx >= 0; idx--) {
       sum *= TAG_VALUE_CARDINALITY.get(idx);
-      LEVEL_CARDINALITY[idx] = sum;
+      LEVEL_CARDINALITY.set(idx, sum);
     }
   }
 
@@ -92,21 +94,33 @@ public class MetaUtil {
     CLIENT_FILES = clientFiles;
   }
 
-  public static Map<String, String> getTag(String deviceName) {
+  /**
+   * Get tags pair by deviceName.
+   *
+   * @param deviceName deviceName
+   * @return tags pair
+   */
+  public static Map<String, String> getTags(String deviceName) {
     if (TAG_NUMBER == 0) {
       return Collections.emptyMap();
     }
     long id = Math.abs(deviceName.hashCode());
     Map<String, String> res = new HashMap<>();
-    for (int i = 0; i < LEVEL_CARDINALITY.length - 1; i++) {
-      id = id % LEVEL_CARDINALITY[i];
-      long tagValueId = id / LEVEL_CARDINALITY[i + 1];
+    for (int i = 0; i < LEVEL_CARDINALITY.size() - 1; i++) {
+      id = id % LEVEL_CARDINALITY.get(i);
+      long tagValueId = id / LEVEL_CARDINALITY.get(i + 1);
       res.put(TAG_KEY_PREFIX + i, TAG_VALUE_PREFIX + tagValueId);
     }
     return res;
   }
 
-  public static Map<String, String> getTag(int deviceId) {
-    return getTag(getDeviceName(deviceId));
+  /**
+   * Get tags pair by deviceId.
+   *
+   * @param deviceId deviceId
+   * @return tags pair
+   */
+  public static Map<String, String> getTags(int deviceId) {
+    return getTags(getDeviceName(deviceId));
   }
 }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
@@ -17,11 +17,11 @@ public class MetaUtil {
   private static final String TAG_VALUE_PREFIX = config.getTAG_VALUE_PREFIX();
   private static final int TAG_NUMBER = config.getTAG_NUMBER();
   private static final List<Integer> TAG_VALUE_CARDINALITY = config.getTAG_VALUE_CARDINALITY();
-  private static final int[] LEVEL_CARDINALITY = new int[TAG_VALUE_CARDINALITY.size() + 1];
+  private static final long[] LEVEL_CARDINALITY = new long[TAG_VALUE_CARDINALITY.size() + 1];
 
   static {
     int idx = TAG_VALUE_CARDINALITY.size();
-    int sum = 1;
+    long sum = 1;
     LEVEL_CARDINALITY[idx--] = 1;
     for (; idx >= 0; idx--) {
       sum *= TAG_VALUE_CARDINALITY.get(idx);
@@ -96,11 +96,11 @@ public class MetaUtil {
     if (TAG_NUMBER == 0) {
       return Collections.emptyMap();
     }
-    int id = deviceName.hashCode();
+    long id = Math.abs(deviceName.hashCode());
     Map<String, String> res = new HashMap<>();
     for (int i = 0; i < LEVEL_CARDINALITY.length - 1; i++) {
       id = id % LEVEL_CARDINALITY[i];
-      int tagValueId = id / LEVEL_CARDINALITY[i + 1];
+      long tagValueId = id / LEVEL_CARDINALITY[i + 1];
       res.put(TAG_KEY_PREFIX + i, TAG_VALUE_PREFIX + tagValueId);
     }
     return res;

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
@@ -52,7 +52,7 @@ public class GenerateMetaDataSchema extends MetaDataSchema {
           (clientId < leftClientDeviceNum) ? eachClientDeviceNum + 1 : eachClientDeviceNum;
       List<DeviceSchema> deviceSchemaList = new ArrayList<>();
       for (int d = 0; d < deviceNumber; d++) {
-        DeviceSchema deviceSchema = new DeviceSchema(deviceId, sensors, config.getDEVICE_TAGS());
+        DeviceSchema deviceSchema = new DeviceSchema(deviceId, sensors, MetaUtil.getTag(deviceId));
         NAME_DATA_SCHEMA.put(deviceSchema.getDevice(), deviceSchema);
         GROUPS.add(deviceSchema.getGroup());
         deviceSchemaList.add(deviceSchema);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
@@ -52,7 +52,7 @@ public class GenerateMetaDataSchema extends MetaDataSchema {
           (clientId < leftClientDeviceNum) ? eachClientDeviceNum + 1 : eachClientDeviceNum;
       List<DeviceSchema> deviceSchemaList = new ArrayList<>();
       for (int d = 0; d < deviceNumber; d++) {
-        DeviceSchema deviceSchema = new DeviceSchema(deviceId, sensors, MetaUtil.getTag(deviceId));
+        DeviceSchema deviceSchema = new DeviceSchema(deviceId, sensors, MetaUtil.getTags(deviceId));
         NAME_DATA_SCHEMA.put(deviceSchema.getDevice(), deviceSchema);
         GROUPS.add(deviceSchema.getGroup());
         deviceSchemaList.add(deviceSchema);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
@@ -73,7 +73,7 @@ public class RealMetaDataSchema extends MetaDataSchema {
               MetaUtil.getGroupIdFromDeviceName(deviceName),
               deviceName,
               sensors,
-              MetaUtil.getTag(deviceName));
+              MetaUtil.getTags(deviceName));
       NAME_DATA_SCHEMA.put(deviceName, deviceSchema);
       GROUPS.add(deviceSchema.getGroup());
       deviceSchemaList.add(deviceSchema);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
@@ -73,7 +73,7 @@ public class RealMetaDataSchema extends MetaDataSchema {
               MetaUtil.getGroupIdFromDeviceName(deviceName),
               deviceName,
               sensors,
-              config.getDEVICE_TAGS());
+              MetaUtil.getTag(deviceName));
       NAME_DATA_SCHEMA.put(deviceName, deviceSchema);
       GROUPS.add(deviceSchema.getGroup());
       deviceSchemaList.add(deviceSchema);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReader.java
@@ -80,7 +80,7 @@ public class CSVDataReader extends DataReader {
                   MetaUtil.getGroupIdFromDeviceName(deviceName),
                   deviceName,
                   sensors,
-                  config.getDEVICE_TAGS());
+                  MetaUtil.getTag(deviceName));
           firstLine = false;
           continue;
         }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReader.java
@@ -80,7 +80,7 @@ public class CSVDataReader extends DataReader {
                   MetaUtil.getGroupIdFromDeviceName(deviceName),
                   deviceName,
                   sensors,
-                  MetaUtil.getTag(deviceName));
+                  MetaUtil.getTags(deviceName));
           firstLine = false;
           continue;
         }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReader.java
@@ -90,7 +90,7 @@ public class CopyDataReader extends DataReader {
                   MetaUtil.getGroupIdFromDeviceName(deviceName),
                   deviceName,
                   sensors,
-                  MetaUtil.getTag(deviceName));
+                  MetaUtil.getTags(deviceName));
           firstLine = false;
           continue;
         }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReader.java
@@ -90,7 +90,7 @@ public class CopyDataReader extends DataReader {
                   MetaUtil.getGroupIdFromDeviceName(deviceName),
                   deviceName,
                   sensors,
-                  config.getDEVICE_TAGS());
+                  MetaUtil.getTag(deviceName));
           firstLine = false;
           continue;
         }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/GenerateQueryWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/GenerateQueryWorkLoad.java
@@ -25,6 +25,7 @@ import cn.edu.tsinghua.iot.benchmark.entity.Batch.IBatch;
 import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.exception.WorkloadException;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.enums.DBSwitch;
 import cn.edu.tsinghua.iot.benchmark.utils.TimeUtils;
@@ -165,7 +166,7 @@ public class GenerateQueryWorkLoad extends QueryWorkLoad {
       return null;
     }
     DeviceSchema deviceSchema =
-        new DeviceSchema(deviceId, config.getSENSORS(), config.getDEVICE_TAGS());
+        new DeviceSchema(deviceId, config.getSENSORS(), MetaUtil.getTag(deviceId));
     return new DeviceQuery(deviceSchema);
   }
 
@@ -234,7 +235,8 @@ public class GenerateQueryWorkLoad extends QueryWorkLoad {
       if (querySensors.size() != config.getQUERY_SENSOR_NUM()) {
         continue;
       }
-      DeviceSchema deviceSchema = new DeviceSchema(deviceId, querySensors, config.getDEVICE_TAGS());
+      DeviceSchema deviceSchema =
+          new DeviceSchema(deviceId, querySensors, MetaUtil.getTag(deviceId));
       queryDevices.add(deviceSchema);
     }
     if (queryDevices.size() != config.getQUERY_DEVICE_NUM()) {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/GenerateQueryWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/GenerateQueryWorkLoad.java
@@ -166,7 +166,7 @@ public class GenerateQueryWorkLoad extends QueryWorkLoad {
       return null;
     }
     DeviceSchema deviceSchema =
-        new DeviceSchema(deviceId, config.getSENSORS(), MetaUtil.getTag(deviceId));
+        new DeviceSchema(deviceId, config.getSENSORS(), MetaUtil.getTags(deviceId));
     return new DeviceQuery(deviceSchema);
   }
 
@@ -236,7 +236,7 @@ public class GenerateQueryWorkLoad extends QueryWorkLoad {
         continue;
       }
       DeviceSchema deviceSchema =
-          new DeviceSchema(deviceId, querySensors, MetaUtil.getTag(deviceId));
+          new DeviceSchema(deviceId, querySensors, MetaUtil.getTags(deviceId));
       queryDevices.add(deviceSchema);
     }
     if (queryDevices.size() != config.getQUERY_DEVICE_NUM()) {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
@@ -89,7 +89,7 @@ public class SingletonWorkDataWorkLoad extends GenerateDataWorkLoad {
           new DeviceSchema(
               MetaUtil.getDeviceId((int) curLoop % config.getDEVICE_NUMBER()),
               sensors,
-              config.getDEVICE_TAGS());
+              MetaUtil.getTag((int) curLoop % config.getDEVICE_NUMBER()));
       // create data of batch
       List<Record> records = new ArrayList<>();
       for (long batchOffset = 0; batchOffset < recordsNumPerDevice; batchOffset++) {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
@@ -89,7 +89,7 @@ public class SingletonWorkDataWorkLoad extends GenerateDataWorkLoad {
           new DeviceSchema(
               MetaUtil.getDeviceId((int) curLoop % config.getDEVICE_NUMBER()),
               sensors,
-              MetaUtil.getTag((int) curLoop % config.getDEVICE_NUMBER()));
+              MetaUtil.getTags((int) curLoop % config.getDEVICE_NUMBER()));
       // create data of batch
       List<Record> records = new ArrayList<>();
       for (long batchOffset = 0; batchOffset < recordsNumPerDevice; batchOffset++) {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SyntheticDataWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SyntheticDataWorkLoad.java
@@ -50,7 +50,7 @@ public class SyntheticDataWorkLoad extends GenerateDataWorkLoad {
               new DeviceSchema(
                   schema.getDeviceId(),
                   Collections.singletonList(sensor),
-                  MetaUtil.getTag(schema.getDeviceId()));
+                  MetaUtil.getTags(schema.getDeviceId()));
           maxTimestampIndexMap.put(deviceSchema, 0L);
         }
       }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SyntheticDataWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SyntheticDataWorkLoad.java
@@ -25,6 +25,7 @@ import cn.edu.tsinghua.iot.benchmark.entity.Batch.MultiDeviceBatch;
 import cn.edu.tsinghua.iot.benchmark.entity.Record;
 import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.exception.WorkloadException;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 
 import java.util.*;
@@ -47,7 +48,9 @@ public class SyntheticDataWorkLoad extends GenerateDataWorkLoad {
         for (Sensor sensor : schema.getSensors()) {
           DeviceSchema deviceSchema =
               new DeviceSchema(
-                  schema.getDeviceId(), Collections.singletonList(sensor), config.getDEVICE_TAGS());
+                  schema.getDeviceId(),
+                  Collections.singletonList(sensor),
+                  MetaUtil.getTag(schema.getDeviceId()));
           maxTimestampIndexMap.put(deviceSchema, 0L);
         }
       }

--- a/iotdb-0.12/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb012/IoTDB.java
+++ b/iotdb-0.12/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb012/IoTDB.java
@@ -36,6 +36,7 @@ import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.exception.DBConnectException;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
@@ -599,7 +600,7 @@ public class IoTDB implements IDatabase {
   protected String getDevicePath(DeviceSchema deviceSchema) {
     StringBuilder name = new StringBuilder(ROOT_SERIES_NAME);
     name.append(".").append(deviceSchema.getGroup());
-    for (Map.Entry<String, String> pair : config.getDEVICE_TAGS().entrySet()) {
+    for (Map.Entry<String, String> pair : MetaUtil.getTag(deviceSchema.getDevice()).entrySet()) {
       name.append(".").append(pair.getValue());
     }
     name.append(".").append(deviceSchema.getDevice());

--- a/iotdb-0.12/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb012/IoTDB.java
+++ b/iotdb-0.12/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb012/IoTDB.java
@@ -36,7 +36,6 @@ import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.exception.DBConnectException;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
-import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
@@ -600,7 +599,7 @@ public class IoTDB implements IDatabase {
   protected String getDevicePath(DeviceSchema deviceSchema) {
     StringBuilder name = new StringBuilder(ROOT_SERIES_NAME);
     name.append(".").append(deviceSchema.getGroup());
-    for (Map.Entry<String, String> pair : MetaUtil.getTag(deviceSchema.getDevice()).entrySet()) {
+    for (Map.Entry<String, String> pair : deviceSchema.getTags().entrySet()) {
       name.append(".").append(pair.getValue());
     }
     name.append(".").append(deviceSchema.getDevice());

--- a/iotdb-0.13/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb013/IoTDB.java
+++ b/iotdb-0.13/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb013/IoTDB.java
@@ -39,7 +39,6 @@ import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.exception.DBConnectException;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
-import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
@@ -653,7 +652,7 @@ public class IoTDB implements IDatabase {
   protected String getDevicePath(DeviceSchema deviceSchema) {
     StringBuilder name = new StringBuilder(ROOT_SERIES_NAME);
     name.append(".").append(deviceSchema.getGroup());
-    for (Map.Entry<String, String> pair : MetaUtil.getTag(deviceSchema.getDevice()).entrySet()) {
+    for (Map.Entry<String, String> pair : deviceSchema.getTags().entrySet()) {
       name.append(".").append(pair.getValue());
     }
     name.append(".").append(deviceSchema.getDevice());

--- a/iotdb-0.13/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb013/IoTDB.java
+++ b/iotdb-0.13/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb013/IoTDB.java
@@ -39,6 +39,7 @@ import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.exception.DBConnectException;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
@@ -652,7 +653,7 @@ public class IoTDB implements IDatabase {
   protected String getDevicePath(DeviceSchema deviceSchema) {
     StringBuilder name = new StringBuilder(ROOT_SERIES_NAME);
     name.append(".").append(deviceSchema.getGroup());
-    for (Map.Entry<String, String> pair : config.getDEVICE_TAGS().entrySet()) {
+    for (Map.Entry<String, String> pair : MetaUtil.getTag(deviceSchema.getDevice()).entrySet()) {
       name.append(".").append(pair.getValue());
     }
     name.append(".").append(deviceSchema.getDevice());

--- a/iotdb-1.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb100/IoTDB.java
+++ b/iotdb-1.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb100/IoTDB.java
@@ -39,7 +39,6 @@ import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.exception.DBConnectException;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
-import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
@@ -653,7 +652,7 @@ public class IoTDB implements IDatabase {
   protected String getDevicePath(DeviceSchema deviceSchema) {
     StringBuilder name = new StringBuilder(ROOT_SERIES_NAME);
     name.append(".").append(deviceSchema.getGroup());
-    for (Map.Entry<String, String> pair : MetaUtil.getTag(deviceSchema.getDevice()).entrySet()) {
+    for (Map.Entry<String, String> pair : deviceSchema.getTags().entrySet()) {
       name.append(".").append(pair.getValue());
     }
     name.append(".").append(deviceSchema.getDevice());

--- a/iotdb-1.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb100/IoTDB.java
+++ b/iotdb-1.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb100/IoTDB.java
@@ -39,6 +39,7 @@ import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.exception.DBConnectException;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
@@ -652,7 +653,7 @@ public class IoTDB implements IDatabase {
   protected String getDevicePath(DeviceSchema deviceSchema) {
     StringBuilder name = new StringBuilder(ROOT_SERIES_NAME);
     name.append(".").append(deviceSchema.getGroup());
-    for (Map.Entry<String, String> pair : config.getDEVICE_TAGS().entrySet()) {
+    for (Map.Entry<String, String> pair : MetaUtil.getTag(deviceSchema.getDevice()).entrySet()) {
       name.append(".").append(pair.getValue());
     }
     name.append(".").append(deviceSchema.getDevice());

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
@@ -39,7 +39,6 @@ import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.exception.DBConnectException;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
-import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
@@ -677,7 +676,7 @@ public class IoTDB implements IDatabase {
   protected String getDevicePath(DeviceSchema deviceSchema) {
     StringBuilder name = new StringBuilder(ROOT_SERIES_NAME);
     name.append(".").append(deviceSchema.getGroup());
-    for (Map.Entry<String, String> pair : MetaUtil.getTag(deviceSchema.getDevice()).entrySet()) {
+    for (Map.Entry<String, String> pair : deviceSchema.getTags().entrySet()) {
       name.append(".").append(pair.getValue());
     }
     name.append(".").append(deviceSchema.getDevice());

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
@@ -39,6 +39,7 @@ import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.exception.DBConnectException;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
@@ -676,7 +677,7 @@ public class IoTDB implements IDatabase {
   protected String getDevicePath(DeviceSchema deviceSchema) {
     StringBuilder name = new StringBuilder(ROOT_SERIES_NAME);
     name.append(".").append(deviceSchema.getGroup());
-    for (Map.Entry<String, String> pair : config.getDEVICE_TAGS().entrySet()) {
+    for (Map.Entry<String, String> pair : MetaUtil.getTag(deviceSchema.getDevice()).entrySet()) {
       name.append(".").append(pair.getValue());
     }
     name.append(".").append(deviceSchema.getDevice());

--- a/tdengine-3.0/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine3/TDengine.java
+++ b/tdengine-3.0/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine3/TDengine.java
@@ -162,7 +162,7 @@ public class TDengine implements IDatabase {
             params.add(deviceSchema.getDevice());
             params.add(SUPER_TABLE_NAME);
             params.add(deviceSchema.getDevice());
-            params.addAll(MetaUtil.getTag(deviceSchema.getDeviceId()).values());
+            params.addAll(MetaUtil.getTags(deviceSchema.getDeviceId()).values());
             statement.execute(String.format(CREATE_TABLE, params.toArray()));
           }
         }

--- a/tdengine/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine/TDengine.java
+++ b/tdengine/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine/TDengine.java
@@ -171,7 +171,7 @@ public class TDengine implements IDatabase {
           params.add(deviceSchema.getDevice());
           params.add(SUPER_TABLE_NAME);
           params.add(deviceSchema.getDevice());
-          params.addAll(MetaUtil.getTag(deviceSchema.getDeviceId()).values());
+          params.addAll(MetaUtil.getTags(deviceSchema.getDeviceId()).values());
           statement.execute(String.format(CREATE_TABLE, params.toArray()));
         }
       } catch (SQLException e) {

--- a/tdengine/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine/TDengine.java
+++ b/tdengine/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine/TDengine.java
@@ -26,6 +26,7 @@ import cn.edu.tsinghua.iot.benchmark.entity.Record;
 import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
@@ -47,8 +48,8 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class TDengine implements IDatabase {
   private static final Config config = ConfigDescriptor.getInstance().getConfig();
@@ -77,9 +78,9 @@ public class TDengine implements IDatabase {
             "create stable if not exists %s (time timestamp, %s) tags(device binary(20)");
     StringBuilder createTable =
         new StringBuilder("create table if not exists %s using %s tags('%s'");
-    for (Map.Entry<String, String> pair : config.getDEVICE_TAGS().entrySet()) {
-      createStable.append(", ").append(pair.getKey()).append(" binary(20)");
-      createTable.append(", '").append(pair.getValue()).append("'");
+    for (int i = 0; i < config.getTAG_NUMBER(); i++) {
+      createStable.append(", ").append(config.getTAG_KEY_PREFIX()).append(i).append(" binary(20)");
+      createTable.append(", '").append("%s").append("'");
     }
     createStable.append(")");
     createTable.append(")");
@@ -166,12 +167,12 @@ public class TDengine implements IDatabase {
         // create tables
         statement.execute(String.format(USE_DB, testDatabaseName));
         for (DeviceSchema deviceSchema : schemaList) {
-          statement.execute(
-              String.format(
-                  CREATE_TABLE,
-                  deviceSchema.getDevice(),
-                  SUPER_TABLE_NAME,
-                  deviceSchema.getDevice()));
+          List<String> params = new ArrayList<>();
+          params.add(deviceSchema.getDevice());
+          params.add(SUPER_TABLE_NAME);
+          params.add(deviceSchema.getDevice());
+          params.addAll(MetaUtil.getTag(deviceSchema.getDeviceId()).values());
+          statement.execute(String.format(CREATE_TABLE, params.toArray()));
         }
       } catch (SQLException e) {
         // ignore if already has the time series

--- a/timescaledb-cluster/src/main/java/cn/edu/tsinghua/iot/benchmark/timescaledbCluster/TimescaleDB.java
+++ b/timescaledb-cluster/src/main/java/cn/edu/tsinghua/iot/benchmark/timescaledbCluster/TimescaleDB.java
@@ -607,8 +607,8 @@ public class TimescaleDB implements IDatabase {
     StringBuilder sqlBuilder = new StringBuilder("CREATE TABLE ").append(tableName).append(" (");
     sqlBuilder.append(
         "time BIGINT NOT NULL, location TEXT NOT NULL, sGroup TEXT NOT NULL, device TEXT NOT NULL");
-    for (Map.Entry<String, String> pair : config.getDEVICE_TAGS().entrySet()) {
-      sqlBuilder.append(", ").append(pair.getKey()).append(" TEXT NOT NULL");
+    for (int i = 0; i < config.getTAG_NUMBER(); i++) {
+      sqlBuilder.append(", ").append(config.getTAG_KEY_PREFIX()).append(i).append(" TEXT NOT NULL");
     }
     for (int i = 0; i < sensors.size(); i++) {
       sqlBuilder
@@ -619,8 +619,8 @@ public class TimescaleDB implements IDatabase {
           .append(" NULL ");
     }
     sqlBuilder.append(",UNIQUE (time, location, sGroup, device");
-    for (Map.Entry<String, String> pair : config.getDEVICE_TAGS().entrySet()) {
-      sqlBuilder.append(", ").append(pair.getKey());
+    for (int i = 0; i < config.getTAG_NUMBER(); i++) {
+      sqlBuilder.append(", ").append(config.getTAG_KEY_PREFIX()).append(i);
     }
     sqlBuilder.append("));");
     return sqlBuilder.toString();

--- a/timescaledb/src/main/java/cn/edu/tsinghua/iot/benchmark/timescaledb/TimescaleDB.java
+++ b/timescaledb/src/main/java/cn/edu/tsinghua/iot/benchmark/timescaledb/TimescaleDB.java
@@ -603,8 +603,8 @@ public class TimescaleDB implements IDatabase {
   private String getCreateTableSql(String tableName, List<Sensor> sensors) {
     StringBuilder sqlBuilder = new StringBuilder("CREATE TABLE ").append(tableName).append(" (");
     sqlBuilder.append("time BIGINT NOT NULL, sGroup TEXT NOT NULL, device TEXT NOT NULL");
-    for (Map.Entry<String, String> pair : config.getDEVICE_TAGS().entrySet()) {
-      sqlBuilder.append(", ").append(pair.getKey()).append(" TEXT NOT NULL");
+    for (int i = 0; i < config.getTAG_NUMBER(); i++) {
+      sqlBuilder.append(", ").append(config.getTAG_KEY_PREFIX()).append(i).append(" TEXT NOT NULL");
     }
     for (int i = 0; i < sensors.size(); i++) {
       sqlBuilder
@@ -615,8 +615,8 @@ public class TimescaleDB implements IDatabase {
           .append(" NULL ");
     }
     sqlBuilder.append(",UNIQUE (time, sGroup, device");
-    for (Map.Entry<String, String> pair : config.getDEVICE_TAGS().entrySet()) {
-      sqlBuilder.append(", ").append(pair.getKey());
+    for (int i = 0; i < config.getTAG_NUMBER(); i++) {
+      sqlBuilder.append(", ").append(config.getTAG_KEY_PREFIX()).append(i);
     }
     sqlBuilder.append("));");
     return sqlBuilder.toString();


### PR DESCRIPTION
Old configuration makes all devices have the same tag.
```
# 标签名的前缀
# TAG_NAME_PREFIX=tag_

# 定义设备标签值，所有设备相同，使用逗号分开，目前支持iotdb-0.12, iotdb-0.13, influxdb-2.x, timescaledb, tdengine
# DEVICE_TAGS=
```

New configuration automatically generates different tags for different devices. Tags will be generated based on the hash value of the deviceName.
```
# 标签名数量
# TAG_NUMBER=0

# 标签名前缀
# TAG_KEY_PREFIX=tag_

# 标签值前缀
# TAG_VALUE_PREFIX=value_

# 每个标签值的取值种数，使用逗号分开，设置个数应与标签名数量相等。例如TAG_NUMBER=2，TAG_VALUE_CARDINALITY=50,10，说明第一个标签名可能有50种值，第二个标签名可能有10种值
# TAG_VALUE_CARDINALITY=
```

For example：
```
# 25000device
# Tags: 品牌, 项目, 车型
TAG_NUMBER=3
TAG_KEY_PREFIX=tag_
TAG_VALUE_PREFIX=value_
TAG_VALUE_CARDINALITY=50,50,10
```
