### PR TITLE
Support nodeurls in session mode

### DIFF
--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSession.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDBSession.java
@@ -32,6 +32,7 @@ import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.TsdbException;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 
@@ -159,11 +160,14 @@ public class IoTDBSession extends IoTDBSessionBase {
   public IoTDBSession(DBConfig dbConfig) {
     super(dbConfig);
     LOGGER = LoggerFactory.getLogger(IoTDBSession.class);
+    List<String> hostUrls = new ArrayList<>(dbConfig.getHOST().size());
+    for (int i = 0; i < dbConfig.getHOST().size(); i++) {
+      hostUrls.add(dbConfig.getHOST().get(i) + ":" + dbConfig.getPORT().get(i));
+    }
     sessionWrapper =
         new BenchmarkSession(
             new Session.Builder()
-                .host(dbConfig.getHOST().get(0))
-                .port(Integer.parseInt(dbConfig.getPORT().get(0)))
+                .nodeUrls(hostUrls)
                 .username(dbConfig.getUSERNAME())
                 .password(dbConfig.getPASSWORD())
                 .enableRedirection(true)


### PR DESCRIPTION
Previously, we only use first hostname for Session mode, this will cause error continuing throwing if we kill one node in iotdb cluster.
So we need to use nodeurls in sessio mode.

Before:
![image](https://github.com/thulab/iot-benchmark/assets/16079446/279f52d3-fd3e-464d-90f8-f55b59dd21af)

After:
<img width="1920" alt="image" src="https://github.com/thulab/iot-benchmark/assets/16079446/e460ded3-f2f7-4c09-a4f3-94c90318a2f7">
