### PR TITLE
Throw exception when DB_SWITCH is invalid

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/enums/DBSwitch.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/enums/DBSwitch.java
@@ -72,9 +72,9 @@ public enum DBSwitch {
   DB_SelfCheck(DBType.SelfCheck, null, null);
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DBSwitch.class);
-  DBType type;
-  DBVersion version;
-  DBInsertMode insertMode;
+  final DBType type;
+  final DBVersion version;
+  final DBInsertMode insertMode;
 
   DBSwitch(DBType Type, DBVersion version, DBInsertMode insertMode) {
     this.type = Type;
@@ -100,9 +100,7 @@ public enum DBSwitch {
         return db;
       }
     }
-    DBSwitch db = DBSwitch.DB_IOT_012_SESSION_BY_TABLET;
-    LOGGER.warn("Using default DBType: " + db);
-    return db;
+    throw new RuntimeException(String.format("Parameter dbSwitch %s is not supported", dbSwitch));
   }
 
   @Override


### PR DESCRIPTION
Now if db_switch is invalid, benchmark will use 012 as default. This is bad for debugging. 
So, throw an exception instead.
<img width="979" alt="image" src="https://github.com/thulab/iot-benchmark/assets/90501481/3634a1bf-71c4-4741-8c5c-c0a83ce258ae">
