### PR TITLE
Support "register schema only" by set LOOP=0

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/App.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/App.java
@@ -39,9 +39,7 @@ public class App {
     long initialHeapSize = Runtime.getRuntime().totalMemory();
     long maxHeapSize = Runtime.getRuntime().maxMemory();
     LOGGER.info(
-        "Initial Heap Size: {} bytes, Max Heap Size: {} bytes. ",
-            initialHeapSize, maxHeapSize
-            );
+        "Initial Heap Size: {} bytes, Max Heap Size: {} bytes. ", initialHeapSize, maxHeapSize);
 
     if (args == null || args.length == 0) {
       args = new String[] {"-cf", "configuration/conf"};

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/App.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/App.java
@@ -33,17 +33,15 @@ import org.slf4j.LoggerFactory;
 import java.sql.SQLException;
 
 public class App {
-  private static Logger LOGGER = LoggerFactory.getLogger(Config.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(App.class);
 
   public static void main(String[] args) throws SQLException {
     long initialHeapSize = Runtime.getRuntime().totalMemory();
     long maxHeapSize = Runtime.getRuntime().maxMemory();
     LOGGER.info(
-        "Initial Heap Size: "
-            + initialHeapSize
-            + "bytes, Max Heap Size: "
-            + maxHeapSize
-            + "bytes.");
+        "Initial Heap Size: {} bytes, Max Heap Size: {} bytes. ",
+            initialHeapSize, maxHeapSize
+            );
 
     if (args == null || args.length == 0) {
       args = new String[] {"-cf", "configuration/conf"};
@@ -54,7 +52,7 @@ public class App {
     }
     Runtime.getRuntime().addShutdownHook(new CSVShutdownHook());
     Config config = ConfigDescriptor.getInstance().getConfig();
-    BaseMode baseMode = null;
+    BaseMode baseMode;
     switch (config.getBENCHMARK_WORK_MODE()) {
       case TEST_WITH_DEFAULT_PATH:
         baseMode = new TestWithDefaultPathMode();

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -621,14 +621,7 @@ public class ConfigDescriptor {
         != config.getOPERATION_PROPORTION_LEN()) {
       config.setOPERATION_PROPORTION(config.getOPERATION_PROPORTION() + ":0");
     }
-    String[] op = config.getOPERATION_PROPORTION().split(":");
-    int minOps = 0;
-    for (String s : op) {
-      if (Double.parseDouble(s) > 1e-7) {
-        minOps++;
-      }
-    }
-    if (minOps > config.getLOOP()) {
+    if (config.getLOOP()<0) {
       LOGGER.error("Loop is too small that can't meet the need of OPERATION_PROPORTION");
       return false;
     }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -621,7 +621,7 @@ public class ConfigDescriptor {
         != config.getOPERATION_PROPORTION_LEN()) {
       config.setOPERATION_PROPORTION(config.getOPERATION_PROPORTION() + ":0");
     }
-    if (config.getLOOP()<0) {
+    if (config.getLOOP() < 0) {
       LOGGER.error("Loop is too small that can't meet the need of OPERATION_PROPORTION");
       return false;
     }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -621,7 +621,14 @@ public class ConfigDescriptor {
         != config.getOPERATION_PROPORTION_LEN()) {
       config.setOPERATION_PROPORTION(config.getOPERATION_PROPORTION() + ":0");
     }
-    if (config.getLOOP() < 0) {
+    String[] op = config.getOPERATION_PROPORTION().split(":");
+    int minOps = 0;
+    for (String s : op) {
+      if (Double.parseDouble(s) > 1e-7) {
+        minOps++;
+      }
+    }
+    if (minOps > config.getLOOP()) {
       LOGGER.error("Loop is too small that can't meet the need of OPERATION_PROPORTION");
       return false;
     }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -628,7 +628,7 @@ public class ConfigDescriptor {
         minOps++;
       }
     }
-    if (config.getLOOP()!=0 && minOps > config.getLOOP()) {
+    if (config.getLOOP() != 0 && minOps > config.getLOOP()) {
       LOGGER.error("Loop is too small that can't meet the need of OPERATION_PROPORTION");
       return false;
     }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -628,7 +628,7 @@ public class ConfigDescriptor {
         minOps++;
       }
     }
-    if (minOps > config.getLOOP()) {
+    if (config.getLOOP()!=0 && minOps > config.getLOOP()) {
       LOGGER.error("Loop is too small that can't meet the need of OPERATION_PROPORTION");
       return false;
     }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
@@ -62,7 +62,7 @@ public abstract class BaseMode {
   protected Measurement measurement = new Measurement();
   protected long start = 0;
 
-  protected boolean preCheck(){
+  protected boolean preCheck() {
     List<DBConfig> dbConfigs = new ArrayList<>();
     dbConfigs.add(config.getDbConfig());
     if (config.isIS_DOUBLE_WRITE()) {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
@@ -62,7 +62,17 @@ public abstract class BaseMode {
   protected Measurement measurement = new Measurement();
   protected long start = 0;
 
-  protected abstract boolean preCheck();
+  protected boolean preCheck(){
+    List<DBConfig> dbConfigs = new ArrayList<>();
+    dbConfigs.add(config.getDbConfig());
+    if (config.isIS_DOUBLE_WRITE()) {
+      dbConfigs.add(config.getANOTHER_DBConfig());
+    }
+    if (config.isIS_DELETE_DATA() && (!cleanUpData(dbConfigs, measurement))) {
+      return false;
+    }
+    return !config.isCREATE_SCHEMA() || (registerSchema(measurement));
+  }
 
   /** Start benchmark */
   public void run() {
@@ -179,7 +189,7 @@ public abstract class BaseMode {
       // must call calculateMetrics() before using the Metrics
       try {
         measurement.calculateMetrics(operations);
-        if (operations.size() != 0) {
+        if (!operations.isEmpty()) {
           measurement.showMeasurements(operations);
           measurement.showMetrics(operations);
         }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
@@ -62,17 +62,7 @@ public abstract class BaseMode {
   protected Measurement measurement = new Measurement();
   protected long start = 0;
 
-  protected boolean preCheck() {
-    List<DBConfig> dbConfigs = new ArrayList<>();
-    dbConfigs.add(config.getDbConfig());
-    if (config.isIS_DOUBLE_WRITE()) {
-      dbConfigs.add(config.getANOTHER_DBConfig());
-    }
-    if (config.isIS_DELETE_DATA() && (!cleanUpData(dbConfigs, measurement))) {
-      return false;
-    }
-    return !config.isCREATE_SCHEMA() || (registerSchema(measurement));
-  }
+  protected abstract boolean preCheck();
 
   /** Start benchmark */
   public void run() {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/GenerateDataMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/GenerateDataMode.java
@@ -40,8 +40,8 @@ public class GenerateDataMode extends BaseMode {
 
   @Override
   protected void postCheck() {
-    LOGGER.info("Data Location: {}" ,config.getFILE_PATH());
-    LOGGER.info("Schema Location: {}",FileUtils.union(config.getFILE_PATH(), "schema.txt"));
-    LOGGER.info("Generate Info Location: {}",FileUtils.union(config.getFILE_PATH(), "info.txt"));
+    LOGGER.info("Data Location: {}", config.getFILE_PATH());
+    LOGGER.info("Schema Location: {}", FileUtils.union(config.getFILE_PATH(), "schema.txt"));
+    LOGGER.info("Generate Info Location: {}", FileUtils.union(config.getFILE_PATH(), "info.txt"));
   }
 }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/GenerateDataMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/GenerateDataMode.java
@@ -40,8 +40,8 @@ public class GenerateDataMode extends BaseMode {
 
   @Override
   protected void postCheck() {
-    LOGGER.info("Data Location: " + config.getFILE_PATH());
-    LOGGER.info("Schema Location: " + FileUtils.union(config.getFILE_PATH(), "schema.txt"));
-    LOGGER.info("Generate Info Location: " + FileUtils.union(config.getFILE_PATH(), "info.txt"));
+    LOGGER.info("Data Location: {}" ,config.getFILE_PATH());
+    LOGGER.info("Schema Location: {}",FileUtils.union(config.getFILE_PATH(), "schema.txt"));
+    LOGGER.info("Generate Info Location: {}",FileUtils.union(config.getFILE_PATH(), "info.txt"));
   }
 }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/TestWithDefaultPathMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/TestWithDefaultPathMode.java
@@ -25,7 +25,6 @@ import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
 import cn.edu.tsinghua.iot.benchmark.measurement.persistence.PersistenceFactory;
 import cn.edu.tsinghua.iot.benchmark.measurement.persistence.TestDataPersistence;
-import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/TestWithDefaultPathMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/TestWithDefaultPathMode.java
@@ -47,7 +47,10 @@ public class TestWithDefaultPathMode extends BaseMode {
     if (config.isIS_DELETE_DATA() && (!cleanUpData(dbConfigs, measurement))) {
       return false;
     }
-    return !config.isCREATE_SCHEMA() || (registerSchema(measurement));
+    if (config.isCREATE_SCHEMA() && (!registerSchema(measurement))) {
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/TestWithDefaultPathMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/TestWithDefaultPathMode.java
@@ -25,6 +25,7 @@ import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
 import cn.edu.tsinghua.iot.benchmark.measurement.persistence.PersistenceFactory;
 import cn.edu.tsinghua.iot.benchmark.measurement.persistence.TestDataPersistence;
+import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +39,15 @@ public class TestWithDefaultPathMode extends BaseMode {
     PersistenceFactory persistenceFactory = new PersistenceFactory();
     TestDataPersistence recorder = persistenceFactory.getPersistence();
     recorder.saveTestConfig();
-    return super.preCheck();
+    List<DBConfig> dbConfigs = new ArrayList<>();
+    dbConfigs.add(config.getDbConfig());
+    if (config.isIS_DOUBLE_WRITE()) {
+      dbConfigs.add(config.getANOTHER_DBConfig());
+    }
+    if (config.isIS_DELETE_DATA() && (!cleanUpData(dbConfigs, measurement))) {
+      return false;
+    }
+    return !config.isCREATE_SCHEMA() || (registerSchema(measurement));
   }
 
   @Override

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/TestWithDefaultPathMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/TestWithDefaultPathMode.java
@@ -39,23 +39,7 @@ public class TestWithDefaultPathMode extends BaseMode {
     PersistenceFactory persistenceFactory = new PersistenceFactory();
     TestDataPersistence recorder = persistenceFactory.getPersistence();
     recorder.saveTestConfig();
-
-    List<DBConfig> dbConfigs = new ArrayList<>();
-    dbConfigs.add(config.getDbConfig());
-    if (config.isIS_DOUBLE_WRITE()) {
-      dbConfigs.add(config.getANOTHER_DBConfig());
-    }
-    if (config.isIS_DELETE_DATA()) {
-      if (!cleanUpData(dbConfigs, measurement)) {
-        return false;
-      }
-    }
-    if (config.isCREATE_SCHEMA()) {
-      if (!registerSchema(measurement)) {
-        return false;
-      }
-    }
-    return true;
+    return super.preCheck();
   }
 
   @Override

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationQueryMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationQueryMode.java
@@ -20,12 +20,9 @@
 package cn.edu.tsinghua.iot.benchmark.mode;
 
 import cn.edu.tsinghua.iot.benchmark.client.operation.Operation;
-import cn.edu.tsinghua.iot.benchmark.conf.Config;
-import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,6 +41,6 @@ public class VerificationQueryMode extends BaseMode {
         threadsMeasurements,
         start,
         dataClients,
-            Collections.singletonList(Operation.VERIFICATION_QUERY));
+        Collections.singletonList(Operation.VERIFICATION_QUERY));
   }
 }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationQueryMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationQueryMode.java
@@ -26,11 +26,10 @@ import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class VerificationQueryMode extends BaseMode {
-
-  private static final Config config = ConfigDescriptor.getInstance().getConfig();
 
   @Override
   protected boolean preCheck() {
@@ -45,6 +44,6 @@ public class VerificationQueryMode extends BaseMode {
         threadsMeasurements,
         start,
         dataClients,
-        Arrays.asList(Operation.VERIFICATION_QUERY));
+            Collections.singletonList(Operation.VERIFICATION_QUERY));
   }
 }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationWriteMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationWriteMode.java
@@ -27,30 +27,14 @@ import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class VerificationWriteMode extends BaseMode {
 
-  private static final Config config = ConfigDescriptor.getInstance().getConfig();
-
   @Override
   protected boolean preCheck() {
-    List<DBConfig> dbConfigs = new ArrayList<>();
-    dbConfigs.add(config.getDbConfig());
-    if (config.isIS_DOUBLE_WRITE()) {
-      dbConfigs.add(config.getANOTHER_DBConfig());
-    }
-    if (config.isIS_DELETE_DATA()) {
-      if (!cleanUpData(dbConfigs, measurement)) {
-        return false;
-      }
-    }
-    if (config.isCREATE_SCHEMA()) {
-      if (!registerSchema(measurement)) {
-        return false;
-      }
-    }
-    return true;
+    return super.preCheck();
   }
 
   @Override
@@ -61,6 +45,6 @@ public class VerificationWriteMode extends BaseMode {
         threadsMeasurements,
         start,
         dataClients,
-        new ArrayList<>(Arrays.asList(Operation.INGESTION)));
+        new ArrayList<>(Collections.singletonList(Operation.INGESTION)));
   }
 }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationWriteMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationWriteMode.java
@@ -20,17 +20,29 @@
 package cn.edu.tsinghua.iot.benchmark.mode;
 
 import cn.edu.tsinghua.iot.benchmark.client.operation.Operation;
+import cn.edu.tsinghua.iot.benchmark.conf.Config;
+import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
+import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class VerificationWriteMode extends BaseMode {
+  private static final Config config = ConfigDescriptor.getInstance().getConfig();
 
   @Override
   protected boolean preCheck() {
-    return super.preCheck();
+    List<DBConfig> dbConfigs = new ArrayList<>();
+    dbConfigs.add(config.getDbConfig());
+    if (config.isIS_DOUBLE_WRITE()) {
+      dbConfigs.add(config.getANOTHER_DBConfig());
+    }
+    if (config.isIS_DELETE_DATA() && (!cleanUpData(dbConfigs, measurement))) {
+      return false;
+    }
+    return !config.isCREATE_SCHEMA() || (registerSchema(measurement));
   }
 
   @Override

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationWriteMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationWriteMode.java
@@ -42,7 +42,10 @@ public class VerificationWriteMode extends BaseMode {
     if (config.isIS_DELETE_DATA() && (!cleanUpData(dbConfigs, measurement))) {
       return false;
     }
-    return !config.isCREATE_SCHEMA() || (registerSchema(measurement));
+    if (config.isCREATE_SCHEMA() && (!registerSchema(measurement))) {
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationWriteMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/VerificationWriteMode.java
@@ -20,13 +20,9 @@
 package cn.edu.tsinghua.iot.benchmark.mode;
 
 import cn.edu.tsinghua.iot.benchmark.client.operation.Operation;
-import cn.edu.tsinghua.iot.benchmark.conf.Config;
-import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
-import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
@@ -31,13 +31,11 @@ import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class SingletonWorkDataWorkLoad extends GenerateDataWorkLoad {
   private static final List<Sensor> SENSORS = Collections.synchronizedList(config.getSENSORS());
-  private ConcurrentHashMap<Integer, AtomicLong> deviceMaxTimeIndexMap;
   private static SingletonWorkDataWorkLoad singletonWorkDataWorkLoad = null;
   private static final AtomicInteger sensorIndex = new AtomicInteger();
   private final AtomicLong insertLoop = new AtomicLong(0);
@@ -46,10 +44,6 @@ public class SingletonWorkDataWorkLoad extends GenerateDataWorkLoad {
     if (config.isIS_OUT_OF_ORDER()) {
       long startIndex = (long) (config.getLOOP() * config.getOUT_OF_ORDER_RATIO());
       this.insertLoop.set(startIndex);
-    }
-    deviceMaxTimeIndexMap = new ConcurrentHashMap<>();
-    for (int i = 0; i < config.getDEVICE_NUMBER(); i++) {
-      deviceMaxTimeIndexMap.put(MetaUtil.getDeviceId(i), new AtomicLong(0));
     }
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SyntheticDataWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SyntheticDataWorkLoad.java
@@ -25,14 +25,11 @@ import cn.edu.tsinghua.iot.benchmark.entity.Batch.MultiDeviceBatch;
 import cn.edu.tsinghua.iot.benchmark.entity.Record;
 import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.exception.WorkloadException;
-import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 
 import java.util.*;
 
 public class SyntheticDataWorkLoad extends GenerateDataWorkLoad {
-
-  private final Map<DeviceSchema, Long> maxTimestampIndexMap;
   private long insertLoop = 0;
   private int deviceIndex = 0;
   private int sensorIndex = 0;
@@ -40,21 +37,6 @@ public class SyntheticDataWorkLoad extends GenerateDataWorkLoad {
 
   public SyntheticDataWorkLoad(List<DeviceSchema> deviceSchemas) {
     this.deviceSchemas = deviceSchemas;
-    maxTimestampIndexMap = new HashMap<>();
-    for (DeviceSchema schema : deviceSchemas) {
-      if (config.isIS_SENSOR_TS_ALIGNMENT()) {
-        maxTimestampIndexMap.put(schema, 0L);
-      } else {
-        for (Sensor sensor : schema.getSensors()) {
-          DeviceSchema deviceSchema =
-              new DeviceSchema(
-                  schema.getDeviceId(),
-                  Collections.singletonList(sensor),
-                  MetaUtil.getTags(schema.getDeviceId()));
-          maxTimestampIndexMap.put(deviceSchema, 0L);
-        }
-      }
-    }
     this.deviceSchemaSize = deviceSchemas.size();
   }
 

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
@@ -305,18 +305,15 @@ public class IoTDB implements IDatabase {
   private void activateTemplate(Session metaSession, List<TimeseriesSchema> schemaList) {
     List<String> someDevicePaths = new ArrayList<>();
     AtomicLong activatedDeviceCount = new AtomicLong();
-    schemaList.stream()
-        .map(schema -> ROOT_SERIES_NAME + "." + schema.getDeviceSchema().getDevicePath())
-        .forEach(
-            path -> {
-              someDevicePaths.add(path);
-              if (someDevicePaths.size() >= ACTIVATE_TEMPLATE_THRESHOLD) {
-                activateTemplateForSomeDevices(
-                    metaSession, someDevicePaths, activatedDeviceCount.get());
-                activatedDeviceCount.addAndGet(someDevicePaths.size());
-                someDevicePaths.clear();
-              }
-            });
+    for (TimeseriesSchema timeseriesSchema : schemaList) {
+      someDevicePaths.add(timeseriesSchema.getDeviceId());
+      if (someDevicePaths.size() >= ACTIVATE_TEMPLATE_THRESHOLD) {
+        activateTemplateForSomeDevices(
+            metaSession, someDevicePaths, activatedDeviceCount.get());
+        activatedDeviceCount.addAndGet(someDevicePaths.size());
+        someDevicePaths.clear();
+      }
+    }
     if (!someDevicePaths.isEmpty()) {
       activateTemplateForSomeDevices(metaSession, someDevicePaths, activatedDeviceCount.get());
     }

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
@@ -308,8 +308,7 @@ public class IoTDB implements IDatabase {
     for (TimeseriesSchema timeseriesSchema : schemaList) {
       someDevicePaths.add(timeseriesSchema.getDeviceId());
       if (someDevicePaths.size() >= ACTIVATE_TEMPLATE_THRESHOLD) {
-        activateTemplateForSomeDevices(
-            metaSession, someDevicePaths, activatedDeviceCount.get());
+        activateTemplateForSomeDevices(metaSession, someDevicePaths, activatedDeviceCount.get());
         activatedDeviceCount.addAndGet(someDevicePaths.size());
         someDevicePaths.clear();
       }


### PR DESCRIPTION
Fix the Out Of Memory issue in Benchmark caused by creating a large number of devices using templates.