### PR TITLE
Add parameters to control the number of schema clients.

### DIFF
--- a/cnosdb/src/main/java/cn/edu/tsinghua/iot/benchmark/cnosdb/CnosConnection.java
+++ b/cnosdb/src/main/java/cn/edu/tsinghua/iot/benchmark/cnosdb/CnosConnection.java
@@ -21,7 +21,7 @@ public class CnosConnection {
 
   CnosConnection(String urlString, String cnosDbName) throws MalformedURLException {
     ConnectionPool connectionPool =
-        new ConnectionPool(config.getCLIENT_NUMBER(), 5, TimeUnit.MINUTES);
+        new ConnectionPool(config.getDATA_CLIENT_NUMBER(), 5, TimeUnit.MINUTES);
     client = new OkHttpClient().newBuilder().connectionPool(connectionPool).build();
     url = urlString + "/api/v1/sql?db=" + cnosDbName;
   }

--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -159,7 +159,7 @@
 # schema 客户端总数，schema_client 负责注册元数据
 # SCHEMA_CLIENT_NUMBER=20
 
-# data 客户端总数, data_client 负责读写
+# data 客户端总数, data_client 负责读写数据
 # iotdb表模型下，client数为table数的整数倍
 # DATA_CLIENT_NUMBER=20
 

--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -156,10 +156,10 @@
 # 是否将设备绑定给客户端，如果绑定，则客户端数小于等于设备数，否则可以大于
 # IS_CLIENT_BIND=true
 
-# schema 客户端总数，schema_client 负责注册
+# schema 客户端总数，schema_client 负责注册元数据
 # SCHEMA_CLIENT_NUMBER=20
 
-# data 客户端总数,data_client 负责读写
+# data 客户端总数, data_client 负责读写
 # iotdb表模型下，client数为table数的整数倍
 # DATA_CLIENT_NUMBER=20
 

--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -156,9 +156,12 @@
 # 是否将设备绑定给客户端，如果绑定，则客户端数小于等于设备数，否则可以大于
 # IS_CLIENT_BIND=true
 
-# 客户端总数
+# schema 客户端总数，schema_client 负责注册
+# SCHEMA_CLIENT_NUMBER=20
+
+# data 客户端总数,data_client 负责读写
 # iotdb表模型下，client数为table数的整数倍
-# CLIENT_NUMBER=20
+# DATA_CLIENT_NUMBER=20
 
 ############## 被测系统为IoTDB时扩展参数 ##################
 # 是否使用thrift压缩，需要在iotdb的配置文件iotdb-datanode.properties中设置dn_rpc_thrift_compression_enable=true

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/DataClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/DataClient.java
@@ -83,7 +83,7 @@ public abstract class DataClient implements Runnable {
     this.queryWorkLoad = QueryWorkLoad.getInstance(id);
     this.clientThreadId = id;
     this.clientDeviceSchemas =
-        MetaDataSchema.getInstance().getDeviceSchemaByClientId(clientThreadId);
+        MetaDataSchema.getInstance().getDeviceSchemaByDataClientId(clientThreadId);
     this.service =
         Executors.newSingleThreadScheduledExecutor(
             new NamedThreadFactory("ShowWorkProgress-" + clientThreadId));

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
@@ -60,7 +60,8 @@ public class SchemaClient implements Runnable {
     this.countDownLatch = countDownLatch;
     this.barrier = barrier;
     this.clientThreadId = id;
-    this.deviceSchemas = MetaDataSchema.getInstance().getDeviceSchemaByClientId(clientThreadId);
+    this.deviceSchemas =
+        MetaDataSchema.getInstance().getDeviceSchemaBySchemaClientId(clientThreadId);
     this.deviceSchemasSize = deviceSchemas.size();
     initDBWrappers();
   }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/generate/GenerateDataDeviceClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/generate/GenerateDataDeviceClient.java
@@ -44,7 +44,7 @@ public class GenerateDataDeviceClient extends GenerateBaseClient {
   @Override
   protected void doTest() {
     try {
-      for (int i = 0; i < config.getDEVICE_NUMBER() / config.getCLIENT_NUMBER() + 1; i++) {
+      for (int i = 0; i < config.getDEVICE_NUMBER() / config.getDATA_CLIENT_NUMBER() + 1; i++) {
         DeviceQuery deviceQuery = queryWorkLoad.getDeviceQuery();
         if (deviceQuery == null) {
           break;

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
@@ -185,10 +185,15 @@ public class Config {
    */
   private boolean IS_CLIENT_BIND = true;
   /**
-   * The number of client if IS_CLIENT_BIND = true: this number must be less than or equal to the
-   * number of devices.
+   * The number of schema client if IS_CLIENT_BIND = true: this number must be less than or equal to
+   * the number of devices.
    */
-  private int CLIENT_NUMBER = 20;
+  private int SCHEMA_CLIENT_NUMBER = 20;
+  /**
+   * The number of data client if IS_CLIENT_BIND = true: this number must be less than or equal to
+   * the number of devices.
+   */
+  private int DATA_CLIENT_NUMBER = 20;
 
   /** name prefix of table */
   private String IoTDB_TABLE_NAME_PREFIX = "table_";
@@ -905,12 +910,20 @@ public class Config {
     this.IS_CLIENT_BIND = IS_CLIENT_BIND;
   }
 
-  public int getCLIENT_NUMBER() {
-    return CLIENT_NUMBER;
+  public int getSCHEMA_CLIENT_NUMBER() {
+    return SCHEMA_CLIENT_NUMBER;
   }
 
-  public void setCLIENT_NUMBER(int CLIENT_NUMBER) {
-    this.CLIENT_NUMBER = CLIENT_NUMBER;
+  public void setSCHEMA_CLIENT_NUMBER(int SCHEMA_CLIENT_NUMBER) {
+    this.SCHEMA_CLIENT_NUMBER = SCHEMA_CLIENT_NUMBER;
+  }
+
+  public int getDATA_CLIENT_NUMBER() {
+    return DATA_CLIENT_NUMBER;
+  }
+
+  public void setDATA_CLIENT_NUMBER(int DATA_CLIENT_NUMBER) {
+    this.DATA_CLIENT_NUMBER = DATA_CLIENT_NUMBER;
   }
 
   public int getTAG_NUMBER() {
@@ -1813,7 +1826,8 @@ public class Config {
     configProperties.addProperty("Data Mode", "IS_OUT_OF_ORDER", this.IS_OUT_OF_ORDER);
     configProperties.addProperty("Data Mode", "OUT_OF_ORDER_RATIO", this.OUT_OF_ORDER_RATIO);
     configProperties.addProperty("Data Amount", "OPERATION_PROPORTION", this.OPERATION_PROPORTION);
-    configProperties.addProperty("Data Amount", "CLIENT_NUMBER", this.CLIENT_NUMBER);
+    configProperties.addProperty("Data Amount", "SCHEMA_CLIENT_NUMBER", this.SCHEMA_CLIENT_NUMBER);
+    configProperties.addProperty("Data Amount", "DATA_CLIENT_NUMBER", this.DATA_CLIENT_NUMBER);
     configProperties.addProperty("Data Amount", "LOOP", this.LOOP);
     configProperties.addProperty("Data Amount", "BATCH_SIZE_PER_WRITE", this.BATCH_SIZE_PER_WRITE);
     configProperties.addProperty("Data Amount", "DEVICE_NUM_PER_WRITE", this.DEVICE_NUM_PER_WRITE);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -256,22 +256,20 @@ public class ConfigDescriptor {
         config.setIS_CLIENT_BIND(
             Boolean.parseBoolean(
                 properties.getProperty("IS_CLIENT_BIND", config.isIS_CLIENT_BIND() + "")));
-        config.setSCHEMA_CLIENT_NUMBER(
-            Integer.parseInt(
-                properties.getProperty(
-                    "SCHEMA_CLIENT_NUMBER", config.getSCHEMA_CLIENT_NUMBER() + "")));
-        config.setDATA_CLIENT_NUMBER(
-            Integer.parseInt(
-                properties.getProperty("DATA_CLIENT_NUMBER", config.getDATA_CLIENT_NUMBER() + "")));
 
-        // TODO delete
-        // Ensure that the configuration parameter CLIENT_NUMBER is effective.
-        config.setSCHEMA_CLIENT_NUMBER(
-            Integer.parseInt(
-                properties.getProperty("CLIENT_NUMBER", config.getSCHEMA_CLIENT_NUMBER() + "")));
-        config.setDATA_CLIENT_NUMBER(
-            Integer.parseInt(
-                properties.getProperty("CLIENT_NUMBER", config.getDATA_CLIENT_NUMBER() + "")));
+        String schemaClientNumber = properties.getProperty("SCHEMA_CLIENT_NUMBER");
+        if (schemaClientNumber != null || schemaClientNumber.isEmpty()) {
+          schemaClientNumber =
+              properties.getProperty("CLIENT_NUMBER", config.getSCHEMA_CLIENT_NUMBER() + "");
+        }
+        config.setSCHEMA_CLIENT_NUMBER(Integer.parseInt(schemaClientNumber));
+
+        String dataClientNumber = properties.getProperty("DATA_CLIENT_NUMBER");
+        if (dataClientNumber == null || dataClientNumber.isEmpty()) {
+          dataClientNumber =
+              properties.getProperty("CLIENT_NUMBER", config.getDATA_CLIENT_NUMBER() + "");
+        }
+        config.setDATA_CLIENT_NUMBER(Integer.parseInt(dataClientNumber));
 
         config.setIoTDB_TABLE_NAME_PREFIX(
             properties.getProperty("IoTDB_TABLE_NAME_PREFIX", config.getIoTDB_TABLE_NAME_PREFIX()));

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -258,7 +258,7 @@ public class ConfigDescriptor {
                 properties.getProperty("IS_CLIENT_BIND", config.isIS_CLIENT_BIND() + "")));
 
         String schemaClientNumber = properties.getProperty("SCHEMA_CLIENT_NUMBER");
-        if (schemaClientNumber != null || schemaClientNumber.isEmpty()) {
+        if (schemaClientNumber == null || schemaClientNumber.isEmpty()) {
           schemaClientNumber =
               properties.getProperty("CLIENT_NUMBER", config.getSCHEMA_CLIENT_NUMBER() + "");
         }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -256,9 +256,13 @@ public class ConfigDescriptor {
         config.setIS_CLIENT_BIND(
             Boolean.parseBoolean(
                 properties.getProperty("IS_CLIENT_BIND", config.isIS_CLIENT_BIND() + "")));
-        config.setCLIENT_NUMBER(
+        config.setSCHEMA_CLIENT_NUMBER(
             Integer.parseInt(
-                properties.getProperty("CLIENT_NUMBER", config.getCLIENT_NUMBER() + "")));
+                properties.getProperty(
+                    "SCHEMA_CLIENT_NUMBER", config.getSCHEMA_CLIENT_NUMBER() + "")));
+        config.setDATA_CLIENT_NUMBER(
+            Integer.parseInt(
+                properties.getProperty("DATA_CLIENT_NUMBER", config.getDATA_CLIENT_NUMBER() + "")));
         config.setIoTDB_TABLE_NAME_PREFIX(
             properties.getProperty("IoTDB_TABLE_NAME_PREFIX", config.getIoTDB_TABLE_NAME_PREFIX()));
         config.setGROUP_NAME_PREFIX(
@@ -546,9 +550,11 @@ public class ConfigDescriptor {
     // Checking config according to mode
     switch (config.getBENCHMARK_WORK_MODE()) {
       case TEST_WITH_DEFAULT_PATH:
-        if (config.isIS_CLIENT_BIND() && config.getDEVICE_NUMBER() < config.getCLIENT_NUMBER()) {
+        if (config.isIS_CLIENT_BIND()
+            && config.getDEVICE_NUMBER() < config.getSCHEMA_CLIENT_NUMBER()
+            && config.getDEVICE_NUMBER() < config.getDATA_CLIENT_NUMBER()) {
           LOGGER.error(
-              "In client bind way, the number of client should be less than the number of device");
+              "In client bind way, the number of schema client and data client should be less than the number of device");
           result = false;
         }
         if (!config.hasWrite()) {
@@ -584,7 +590,8 @@ public class ConfigDescriptor {
               }
             }
             if (config.isIS_POINT_COMPARISON()) {
-              if (config.getDEVICE_NUMBER() < config.getCLIENT_NUMBER()) {
+              if (config.getDEVICE_NUMBER() < config.getSCHEMA_CLIENT_NUMBER()
+                  || config.getDEVICE_NUMBER() < config.getDATA_CLIENT_NUMBER()) {
                 LOGGER.warn("There are too many client ( > device number)");
               }
             }
@@ -620,7 +627,7 @@ public class ConfigDescriptor {
     }
     result &= checkInsertDataTypeProportion();
     result &= checkOperationProportion();
-    if (config.getCLIENT_NUMBER() == 0) {
+    if (config.getSCHEMA_CLIENT_NUMBER() == 0 || config.getDATA_CLIENT_NUMBER() == 0) {
       LOGGER.error("Client number can't be zero");
       result = false;
     }
@@ -694,7 +701,7 @@ public class ConfigDescriptor {
     }
     // tableMode
     if (config.getIoTDB_DIALECT_MODE() == SQLDialect.TABLE
-        && config.getCLIENT_NUMBER() % config.getIoTDB_TABLE_NUMBER() != 0) {
+        && config.getDATA_CLIENT_NUMBER() % config.getIoTDB_TABLE_NUMBER() != 0) {
       LOGGER.error(
           "TableMode must ensure that a client only writes to one table. Therefore, a client only switches database once.\n"
               + "please make CLIENT_NUMBER % IoTDB_TABLE_NUMBER == 0");
@@ -714,7 +721,7 @@ public class ConfigDescriptor {
     }
     for (int deviceNumPerClient :
         CommonAlgorithms.distributeDevicesToClients(
-                config.getDEVICE_NUMBER(), config.getCLIENT_NUMBER())
+                config.getDEVICE_NUMBER(), config.getDATA_CLIENT_NUMBER())
             .values()) {
       if (deviceNumPerClient % dnw != 0) {
         LOGGER.error(

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -263,6 +263,15 @@ public class ConfigDescriptor {
         config.setDATA_CLIENT_NUMBER(
             Integer.parseInt(
                 properties.getProperty("DATA_CLIENT_NUMBER", config.getDATA_CLIENT_NUMBER() + "")));
+
+        // Ensure that the configuration parameter CLIENT_NUMBER is effective.
+        config.setSCHEMA_CLIENT_NUMBER(
+            Integer.parseInt(
+                properties.getProperty("CLIENT_NUMBER", config.getSCHEMA_CLIENT_NUMBER() + "")));
+        config.setDATA_CLIENT_NUMBER(
+            Integer.parseInt(
+                properties.getProperty("CLIENT_NUMBER", config.getDATA_CLIENT_NUMBER() + "")));
+
         config.setIoTDB_TABLE_NAME_PREFIX(
             properties.getProperty("IoTDB_TABLE_NAME_PREFIX", config.getIoTDB_TABLE_NAME_PREFIX()));
         config.setGROUP_NAME_PREFIX(

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -264,6 +264,7 @@ public class ConfigDescriptor {
             Integer.parseInt(
                 properties.getProperty("DATA_CLIENT_NUMBER", config.getDATA_CLIENT_NUMBER() + "")));
 
+        // TODO delete
         // Ensure that the configuration parameter CLIENT_NUMBER is effective.
         config.setSCHEMA_CLIENT_NUMBER(
             Integer.parseInt(

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -704,7 +704,7 @@ public class ConfigDescriptor {
         && config.getDATA_CLIENT_NUMBER() % config.getIoTDB_TABLE_NUMBER() != 0) {
       LOGGER.error(
           "TableMode must ensure that a client only writes to one table. Therefore, a client only switches database once.\n"
-              + "please make CLIENT_NUMBER % IoTDB_TABLE_NUMBER == 0");
+              + "please make DATA_CLIENT_NUMBER % IoTDB_TABLE_NUMBER == 0");
       return false;
     }
     if (dnw == 1) {
@@ -726,7 +726,7 @@ public class ConfigDescriptor {
       if (deviceNumPerClient % dnw != 0) {
         LOGGER.error(
             "Some clients will be allocated {} devices, which are not divisible by parameter DEVICE_NUM_PER_WRITE {}.\n"
-                + "To solve this problem, please make DEVICE_NUMBER % CLIENTS_NUMBER == 0, and (DEVICE_NUMBER / CLIENT_NUMBER) % DEVICE_NUM_PER_WRITE == 0.",
+                + "To solve this problem, please make DEVICE_NUMBER % CLIENTS_NUMBER == 0, and (DEVICE_NUMBER / DATA_CLIENT_NUMBER) % DEVICE_NUM_PER_WRITE == 0.",
             deviceNumPerClient, dnw);
         return false;
       }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -726,7 +726,7 @@ public class ConfigDescriptor {
       if (deviceNumPerClient % dnw != 0) {
         LOGGER.error(
             "Some clients will be allocated {} devices, which are not divisible by parameter DEVICE_NUM_PER_WRITE {}.\n"
-                + "To solve this problem, please make DEVICE_NUMBER % CLIENTS_NUMBER == 0, and (DEVICE_NUMBER / DATA_CLIENT_NUMBER) % DEVICE_NUM_PER_WRITE == 0.",
+                + "To solve this problem, please make DEVICE_NUMBER % DATA_CLIENT_NUMBER == 0, and (DEVICE_NUMBER / DATA_CLIENT_NUMBER) % DEVICE_NUM_PER_WRITE == 0.",
             deviceNumPerClient, dnw);
         return false;
       }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -372,7 +372,7 @@ public class MySqlRecorder extends TestDataPersistence {
           String.format(
               SAVE_CONFIG,
               "'" + PROJECT_ID + "'",
-              "'getCLIENT_NUMBER()'",
+              "'getDATA_CLIENT_NUMBER()'",
               "'" + config.getDATA_CLIENT_NUMBER() + "'");
       statement.addBatch(sql);
       sql =

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -373,7 +373,7 @@ public class MySqlRecorder extends TestDataPersistence {
               SAVE_CONFIG,
               "'" + PROJECT_ID + "'",
               "'getCLIENT_NUMBER()'",
-              "'" + config.getCLIENT_NUMBER() + "'");
+              "'" + config.getDATA_CLIENT_NUMBER() + "'");
       statement.addBatch(sql);
       sql =
           String.format(

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
@@ -54,13 +54,14 @@ public abstract class BaseMode {
 
   protected ExecutorService schemaExecutorService =
       Executors.newFixedThreadPool(
-          config.getCLIENT_NUMBER(), new NamedThreadFactory("SchemaClient"));
+          config.getSCHEMA_CLIENT_NUMBER(), new NamedThreadFactory("SchemaClient"));
   protected ExecutorService executorService =
-      Executors.newFixedThreadPool(config.getCLIENT_NUMBER(), new NamedThreadFactory("DataClient"));
-  protected CountDownLatch schemaDownLatch = new CountDownLatch(config.getCLIENT_NUMBER());
-  protected CyclicBarrier schemaBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
-  protected CountDownLatch dataDownLatch = new CountDownLatch(config.getCLIENT_NUMBER());
-  protected CyclicBarrier dataBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
+      Executors.newFixedThreadPool(
+          config.getDATA_CLIENT_NUMBER(), new NamedThreadFactory("DataClient"));
+  protected CountDownLatch schemaDownLatch = new CountDownLatch(config.getSCHEMA_CLIENT_NUMBER());
+  protected CyclicBarrier schemaBarrier = new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
+  protected CountDownLatch dataDownLatch = new CountDownLatch(config.getDATA_CLIENT_NUMBER());
+  protected CyclicBarrier dataBarrier = new CyclicBarrier(config.getDATA_CLIENT_NUMBER());
   protected List<DataClient> dataClients = new ArrayList<>();
   protected List<SchemaClient> schemaClients = new ArrayList<>();
   protected Measurement baseModeMeasurement = new Measurement();
@@ -73,7 +74,7 @@ public abstract class BaseMode {
     if (!preCheck()) {
       return;
     }
-    for (int i = 0; i < config.getCLIENT_NUMBER(); i++) {
+    for (int i = 0; i < config.getDATA_CLIENT_NUMBER(); i++) {
       DataClient client = DataClient.getInstance(i, dataDownLatch, dataBarrier);
       if (client == null) {
         return;
@@ -169,7 +170,7 @@ public abstract class BaseMode {
 
   /** Register schema */
   protected boolean registerSchema() {
-    for (int i = 0; i < config.getCLIENT_NUMBER(); i++) {
+    for (int i = 0; i < config.getSCHEMA_CLIENT_NUMBER(); i++) {
       SchemaClient schemaClient = new SchemaClient(i, schemaDownLatch, schemaBarrier);
       schemaClients.add(schemaClient);
     }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
@@ -25,6 +25,7 @@ import cn.edu.tsinghua.iot.benchmark.client.operation.Operation;
 import cn.edu.tsinghua.iot.benchmark.conf.Config;
 import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaDataSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBWrapper;
 import cn.edu.tsinghua.iot.benchmark.tsdb.TsdbException;
@@ -190,6 +191,7 @@ public abstract class BaseMode {
       Thread.currentThread().interrupt();
     }
     LOGGER.info("Registering schema successful!");
+    MetaDataSchema.clearSchemaClientDataSchema();
     return true;
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
@@ -36,8 +36,11 @@ public abstract class MetaDataSchema {
   private static final String UNKNOWN_DEVICE = "Unknown device: %s";
 
   protected static final Config config = ConfigDescriptor.getInstance().getConfig();
-  /** DeviceSchema for each client */
-  protected static final Map<Integer, List<DeviceSchema>> CLIENT_DATA_SCHEMA =
+  /** DeviceSchema for each schema client */
+  protected static final Map<Integer, List<DeviceSchema>> SCHEMA_CLIENT_DATA_SCHEMA =
+      new ConcurrentHashMap<>();
+  /** DeviceSchema for each data client */
+  protected static final Map<Integer, List<DeviceSchema>> DATA_CLIENT_DATA_SCHEMA =
       new ConcurrentHashMap<>();
   /** Name mapping of DeviceSchema */
   protected static final Map<String, DeviceSchema> NAME_DATA_SCHEMA = new ConcurrentHashMap<>();
@@ -65,9 +68,13 @@ public abstract class MetaDataSchema {
     }
   }
 
-  /** Get DeviceSchema by clientId */
-  public List<DeviceSchema> getDeviceSchemaByClientId(int clientId) {
-    return CLIENT_DATA_SCHEMA.get(clientId);
+  /** Get DeviceSchema by schema clientId */
+  public List<DeviceSchema> getDeviceSchemaBySchemaClientId(int clientId) {
+    return SCHEMA_CLIENT_DATA_SCHEMA.get(clientId);
+  }
+  /** Get DeviceSchema by data clientId */
+  public List<DeviceSchema> getDeviceSchemaByDataClientId(int clientId) {
+    return DATA_CLIENT_DATA_SCHEMA.get(clientId);
   }
 
   /** Get All Device Schema */

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
@@ -83,8 +83,8 @@ public abstract class MetaDataSchema {
     List<Integer> deviceIds = MetaUtil.sortDeviceId();
     List<DeviceSchema> deviceSchemaList = new ArrayList<>();
     for (int deviceId : deviceIds) {
-      if (NAME_DATA_SCHEMA.containsKey("d_" + deviceId)) {
-        deviceSchemaList.add(NAME_DATA_SCHEMA.get("d_" + deviceId));
+      if (NAME_DATA_SCHEMA.containsKey(config.getDEVICE_NAME_PREFIX() + deviceId)) {
+        deviceSchemaList.add(NAME_DATA_SCHEMA.get(config.getDEVICE_NAME_PREFIX() + deviceId));
       }
     }
     return new ArrayList<>(deviceSchemaList);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
@@ -80,7 +80,7 @@ public abstract class MetaDataSchema {
 
   /** Get All Device Schema */
   public List<DeviceSchema> getAllDeviceSchemas() {
-    List<Integer> deviceIds = MetaUtil.sortDeviceId(config, LOGGER);
+    List<Integer> deviceIds = MetaUtil.sortDeviceId();
     List<DeviceSchema> deviceSchemaList = new ArrayList<>();
     for (int deviceId : deviceIds) {
       if (NAME_DATA_SCHEMA.containsKey("d_" + deviceId)) {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
@@ -72,6 +72,7 @@ public abstract class MetaDataSchema {
   public List<DeviceSchema> getDeviceSchemaBySchemaClientId(int clientId) {
     return SCHEMA_CLIENT_DATA_SCHEMA.get(clientId);
   }
+
   /** Get DeviceSchema by data clientId */
   public List<DeviceSchema> getDeviceSchemaByDataClientId(int clientId) {
     return DATA_CLIENT_DATA_SCHEMA.get(clientId);
@@ -79,7 +80,14 @@ public abstract class MetaDataSchema {
 
   /** Get All Device Schema */
   public List<DeviceSchema> getAllDeviceSchemas() {
-    return new ArrayList<>(NAME_DATA_SCHEMA.values());
+    List<Integer> deviceIds = MetaUtil.sortDeviceId(config, LOGGER);
+    List<DeviceSchema> deviceSchemaList = new ArrayList<>();
+    for (int deviceId : deviceIds) {
+      if (NAME_DATA_SCHEMA.containsKey("d_" + deviceId)) {
+        deviceSchemaList.add(NAME_DATA_SCHEMA.get("d_" + deviceId));
+      }
+    }
+    return new ArrayList<>(deviceSchemaList);
   }
 
   /** Get All Group */

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaDataSchema.java
@@ -55,6 +55,11 @@ public abstract class MetaDataSchema {
     }
   }
 
+  public static void clearSchemaClientDataSchema() {
+    SCHEMA_CLIENT_DATA_SCHEMA.clear();
+    LOGGER.info("SCHEMA_CLIENT_DATA_SCHEMA has been cleared!");
+  }
+
   /** init data schema for each device */
   protected abstract boolean createMetaDataSchema();
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
@@ -110,9 +110,15 @@ public class MetaUtil {
     return String.valueOf(groupId);
   }
 
-  public static String getTableIdFromDeviceName(String deviceName) {
-    int tableId = Math.abs(deviceName.hashCode());
-    tableId = tableId % config.getIoTDB_TABLE_NUMBER();
+  public static String getTableIdFromDeviceName(String deviceName, Logger LOGGER) {
+    int tableId = -1;
+    try {
+      int deviceId =
+          Integer.parseInt(deviceName.substring(config.getDEVICE_NAME_PREFIX().length()));
+      tableId = mappingId(deviceId, config.getDEVICE_NUMBER(), config.getIoTDB_TABLE_NUMBER());
+    } catch (NumberFormatException | WorkloadException e) {
+      LOGGER.error("getTableIdFromDeviceName failed.", e);
+    }
     return String.valueOf(tableId);
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
@@ -140,7 +140,7 @@ public class MetaUtil {
     return String.valueOf(groupId);
   }
 
-  public static String getTableIdFromDeviceName(String deviceName, Logger LOGGER) {
+  public static String getTableIdFromDeviceName(String deviceName) {
     int tableId = -1;
     try {
       int deviceId =

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
@@ -111,12 +111,12 @@ public class MetaUtil {
       List<Sensor> sensors,
       Map<String, DeviceSchema> nameDataSchema,
       Set<String> groups) {
-    Map<Integer, Integer> deviceDistributionForSchemaClient =
+    Map<Integer, Integer> deviceDistributionForClient =
         CommonAlgorithms.distributeDevicesToClients(config.getDEVICE_NUMBER(), clientNumber);
     int deviceIndex = MetaUtil.getDeviceId(0);
     List<Integer> deviceIds = sortDeviceId();
     for (int clientId = 0; clientId < clientNumber; clientId++) {
-      int deviceNumber = deviceDistributionForSchemaClient.get(clientId);
+      int deviceNumber = deviceDistributionForClient.get(clientId);
       List<DeviceSchema> deviceSchemasList = new ArrayList<>();
       for (int d = 0; d < deviceNumber; d++) {
         DeviceSchema deviceSchema =

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
@@ -8,6 +8,7 @@ import cn.edu.tsinghua.iot.benchmark.exception.WorkloadException;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.utils.CommonAlgorithms;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +20,7 @@ import java.util.Set;
 
 public class MetaUtil {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(MetaUtil.class);
   private static final Config config = ConfigDescriptor.getInstance().getConfig();
   private static final String TAG_KEY_PREFIX = config.getTAG_KEY_PREFIX();
   private static final String TAG_VALUE_PREFIX = config.getTAG_VALUE_PREFIX();
@@ -67,11 +69,9 @@ public class MetaUtil {
    * table.<br>
    * IoTDB-TreeMode : It will not affect its writing speed.
    *
-   * @param config
-   * @param LOGGER
    * @return deviceIds
    */
-  public static List<Integer> sortDeviceId(Config config, Logger LOGGER) {
+  public static List<Integer> sortDeviceId() {
     List<Integer> deviceIds = new ArrayList<>();
     Map<Integer, List<Integer>> tableDeviceMap =
         new HashMap<>(config.getIoTDB_TABLE_NUMBER(), 1.00f);
@@ -114,12 +114,14 @@ public class MetaUtil {
     Map<Integer, Integer> deviceDistributionForSchemaClient =
         CommonAlgorithms.distributeDevicesToClients(config.getDEVICE_NUMBER(), clientNumber);
     int deviceIndex = MetaUtil.getDeviceId(0);
+    List<Integer> deviceIds = sortDeviceId();
     for (int clientId = 0; clientId < clientNumber; clientId++) {
       int deviceNumber = deviceDistributionForSchemaClient.get(clientId);
       List<DeviceSchema> deviceSchemasList = new ArrayList<>();
       for (int d = 0; d < deviceNumber; d++) {
         DeviceSchema deviceSchema =
-            new DeviceSchema(deviceIndex, sensors, MetaUtil.getTags(deviceIndex));
+            new DeviceSchema(
+                deviceIds.get(deviceIndex), sensors, MetaUtil.getTags(deviceIds.get(deviceIndex)));
         deviceSchemasList.add(deviceSchema);
         nameDataSchema.putIfAbsent(deviceSchema.getDevice(), deviceSchema);
         groups.add(deviceSchema.getGroup());

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/DeviceSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/DeviceSchema.java
@@ -83,9 +83,8 @@ public class DeviceSchema implements Cloneable {
     }
   }
 
-  public DeviceSchema(
-      String groupId, String deviceName, List<Sensor> sensors, Map<String, String> tags) {
-    String tableId = MetaUtil.getTableIdFromDeviceName(deviceName);
+  public DeviceSchema(String deviceName, List<Sensor> sensors, Map<String, String> tags) {
+    String tableId = MetaUtil.getTableIdFromDeviceName(deviceName, LOGGER);
     this.table = MetaUtil.getTableName(tableId);
     try {
       this.group =

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/DeviceSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/DeviceSchema.java
@@ -84,7 +84,7 @@ public class DeviceSchema implements Cloneable {
   }
 
   public DeviceSchema(String deviceName, List<Sensor> sensors, Map<String, String> tags) {
-    String tableId = MetaUtil.getTableIdFromDeviceName(deviceName, LOGGER);
+    String tableId = MetaUtil.getTableIdFromDeviceName(deviceName);
     this.table = MetaUtil.getTableName(tableId);
     try {
       this.group =

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
@@ -24,13 +24,10 @@ import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.schema.MetaDataSchema;
 import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
-import cn.edu.tsinghua.iot.benchmark.utils.CommonAlgorithms;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /** Data Schema for generate data */
 public class GenerateMetaDataSchema extends MetaDataSchema {
@@ -45,44 +42,15 @@ public class GenerateMetaDataSchema extends MetaDataSchema {
       return false;
     }
     // schemaClient
-    Map<Integer, Integer> deviceDistributionForSchemaClient =
-        CommonAlgorithms.distributeDevicesToClients(
-            config.getDEVICE_NUMBER(), config.getSCHEMA_CLIENT_NUMBER());
-    int deviceIndexForSchema = MetaUtil.getDeviceId(0);
-    for (int clientId = 0; clientId < config.getSCHEMA_CLIENT_NUMBER(); clientId++) {
-      int deviceNumber = deviceDistributionForSchemaClient.get(clientId);
-      List<DeviceSchema> deviceSchemasList = new ArrayList<>();
-      for (int d = 0; d < deviceNumber; d++) {
-        DeviceSchema deviceSchema =
-            new DeviceSchema(deviceIndexForSchema, sensors, MetaUtil.getTags(deviceIndexForSchema));
-        deviceSchemasList.add(deviceSchema);
-        deviceIndexForSchema++;
-      }
-      SCHEMA_CLIENT_DATA_SCHEMA.put(clientId, deviceSchemasList);
-    }
-
-    // dataClient
-    Map<Integer, Integer> deviceDistributionForDataClient =
-        CommonAlgorithms.distributeDevicesToClients(
-            config.getDEVICE_NUMBER(), config.getDATA_CLIENT_NUMBER());
-    int deviceIndex = MetaUtil.getDeviceId(0);
-    // Rearrange device IDs so that adjacent devices are in the same table
-    List<Integer> deviceIds = MetaUtil.sortDeviceId(config, LOGGER);
-    for (int clientId = 0; clientId < config.getDATA_CLIENT_NUMBER(); clientId++) {
-      int deviceNumber = deviceDistributionForDataClient.get(clientId);
-      List<DeviceSchema> deviceSchemaList = new ArrayList<>();
-      for (int d = 0; d < deviceNumber; d++) {
-        DeviceSchema deviceSchema;
-        deviceSchema =
-            new DeviceSchema(
-                deviceIds.get(deviceIndex), sensors, MetaUtil.getTags(deviceIds.get(deviceIndex)));
-        NAME_DATA_SCHEMA.put(deviceSchema.getDevice(), deviceSchema);
-        GROUPS.add(deviceSchema.getGroup());
-        deviceSchemaList.add(deviceSchema);
-        deviceIndex++;
-      }
-      DATA_CLIENT_DATA_SCHEMA.put(clientId, deviceSchemaList);
-    }
+    MetaUtil.distributeDevices(
+        config.getSCHEMA_CLIENT_NUMBER(),
+        SCHEMA_CLIENT_DATA_SCHEMA,
+        sensors,
+        NAME_DATA_SCHEMA,
+        GROUPS);
+    // dataclient
+    MetaUtil.distributeDevices(
+        config.getDATA_CLIENT_NUMBER(), DATA_CLIENT_DATA_SCHEMA, sensors, NAME_DATA_SCHEMA, GROUPS);
     return true;
   }
 }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
@@ -24,15 +24,12 @@ import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
 import cn.edu.tsinghua.iot.benchmark.schema.MetaDataSchema;
 import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 /** Data Schema for generate data */
 public class GenerateMetaDataSchema extends MetaDataSchema {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(GenerateMetaDataSchema.class);
   private static final Config config = ConfigDescriptor.getInstance().getConfig();
 
   @Override
@@ -48,7 +45,7 @@ public class GenerateMetaDataSchema extends MetaDataSchema {
         sensors,
         NAME_DATA_SCHEMA,
         GROUPS);
-    // dataclient
+    // dataClient
     MetaUtil.distributeDevices(
         config.getDATA_CLIENT_NUMBER(), DATA_CLIENT_DATA_SCHEMA, sensors, NAME_DATA_SCHEMA, GROUPS);
     return true;

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/GenerateMetaDataSchema.java
@@ -44,15 +44,32 @@ public class GenerateMetaDataSchema extends MetaDataSchema {
     if (sensors == null) {
       return false;
     }
-
-    Map<Integer, Integer> deviceDistribution =
+    // schemaClient
+    Map<Integer, Integer> deviceDistributionForSchemaClient =
         CommonAlgorithms.distributeDevicesToClients(
-            config.getDEVICE_NUMBER(), config.getCLIENT_NUMBER());
+            config.getDEVICE_NUMBER(), config.getSCHEMA_CLIENT_NUMBER());
+    int deviceIndexForSchema = MetaUtil.getDeviceId(0);
+    for (int clientId = 0; clientId < config.getSCHEMA_CLIENT_NUMBER(); clientId++) {
+      int deviceNumber = deviceDistributionForSchemaClient.get(clientId);
+      List<DeviceSchema> deviceSchemasList = new ArrayList<>();
+      for (int d = 0; d < deviceNumber; d++) {
+        DeviceSchema deviceSchema =
+            new DeviceSchema(deviceIndexForSchema, sensors, MetaUtil.getTags(deviceIndexForSchema));
+        deviceSchemasList.add(deviceSchema);
+        deviceIndexForSchema++;
+      }
+      SCHEMA_CLIENT_DATA_SCHEMA.put(clientId, deviceSchemasList);
+    }
+
+    // dataClient
+    Map<Integer, Integer> deviceDistributionForDataClient =
+        CommonAlgorithms.distributeDevicesToClients(
+            config.getDEVICE_NUMBER(), config.getDATA_CLIENT_NUMBER());
     int deviceIndex = MetaUtil.getDeviceId(0);
     // Rearrange device IDs so that adjacent devices are in the same table
     List<Integer> deviceIds = MetaUtil.sortDeviceId(config, LOGGER);
-    for (int clientId = 0; clientId < config.getCLIENT_NUMBER(); clientId++) {
-      int deviceNumber = deviceDistribution.get(clientId);
+    for (int clientId = 0; clientId < config.getDATA_CLIENT_NUMBER(); clientId++) {
+      int deviceNumber = deviceDistributionForDataClient.get(clientId);
       List<DeviceSchema> deviceSchemaList = new ArrayList<>();
       for (int d = 0; d < deviceNumber; d++) {
         DeviceSchema deviceSchema;
@@ -64,7 +81,7 @@ public class GenerateMetaDataSchema extends MetaDataSchema {
         deviceSchemaList.add(deviceSchema);
         deviceIndex++;
       }
-      CLIENT_DATA_SCHEMA.put(clientId, deviceSchemaList);
+      DATA_CLIENT_DATA_SCHEMA.put(clientId, deviceSchemaList);
     }
     return true;
   }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
@@ -99,7 +99,7 @@ public class RealMetaDataSchema extends MetaDataSchema {
     Map<Integer, Integer> deviceDistributionForDataClient =
         CommonAlgorithms.distributeDevicesToClients(
             config.getDEVICE_NUMBER(), config.getDATA_CLIENT_NUMBER());
-    List<Integer> deviceIds = MetaUtil.sortDeviceId(config, LOGGER);
+    List<Integer> deviceIds = MetaUtil.sortDeviceId();
     int index = 0;
     for (int clientId = 0; clientId < config.getDATA_CLIENT_NUMBER(); clientId++) {
       int fileNumber = deviceDistributionForDataClient.get(clientId);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
@@ -76,23 +76,19 @@ public class RealMetaDataSchema extends MetaDataSchema {
       deviceSchemaList.add(deviceSchema);
     }
 
-    for (int i = 0; i < deviceSchemaList.size(); i++) {
-      int clientId = i % config.getSCHEMA_CLIENT_NUMBER();
-      DeviceSchema deviceSchema = deviceSchemaList.get(i);
-      if (!SCHEMA_CLIENT_DATA_SCHEMA.containsKey(clientId)) {
-        SCHEMA_CLIENT_DATA_SCHEMA.put(clientId, new ArrayList<>());
-      }
-      SCHEMA_CLIENT_DATA_SCHEMA.get(clientId).add(deviceSchema);
-    }
-
     // Split into client And store Type
     for (int i = 0; i < deviceSchemaList.size(); i++) {
-      int clientId = i % config.getDATA_CLIENT_NUMBER();
+      int schemaClientId = i % config.getSCHEMA_CLIENT_NUMBER();
+      int dataClientId = i % config.getDATA_CLIENT_NUMBER();
       DeviceSchema deviceSchema = deviceSchemaList.get(i);
-      if (!DATA_CLIENT_DATA_SCHEMA.containsKey(clientId)) {
-        DATA_CLIENT_DATA_SCHEMA.put(clientId, new ArrayList<>());
+      if (!SCHEMA_CLIENT_DATA_SCHEMA.containsKey(schemaClientId)) {
+        SCHEMA_CLIENT_DATA_SCHEMA.put(schemaClientId, new ArrayList<>());
       }
-      DATA_CLIENT_DATA_SCHEMA.get(clientId).add(deviceSchema);
+      if (!DATA_CLIENT_DATA_SCHEMA.containsKey(dataClientId)) {
+        DATA_CLIENT_DATA_SCHEMA.put(dataClientId, new ArrayList<>());
+      }
+      SCHEMA_CLIENT_DATA_SCHEMA.get(schemaClientId).add(deviceSchema);
+      DATA_CLIENT_DATA_SCHEMA.get(dataClientId).add(deviceSchema);
     }
 
     // Split data files into data client
@@ -100,7 +96,6 @@ public class RealMetaDataSchema extends MetaDataSchema {
     for (int i = 0; i < config.getDATA_CLIENT_NUMBER(); i++) {
       clientFiles.add(new ArrayList<>());
     }
-
     Map<Integer, Integer> deviceDistributionForDataClient =
         CommonAlgorithms.distributeDevicesToClients(
             config.getDEVICE_NUMBER(), config.getDATA_CLIENT_NUMBER());
@@ -109,7 +104,7 @@ public class RealMetaDataSchema extends MetaDataSchema {
     for (int clientId = 0; clientId < config.getDATA_CLIENT_NUMBER(); clientId++) {
       int fileNumber = deviceDistributionForDataClient.get(clientId);
       for (int fileId = 0; fileId < fileNumber; fileId++, index++) {
-        String device = "d_" + deviceIds.get(index);
+        String device = config.getDEVICE_NAME_PREFIX() + deviceIds.get(index);
         String filePath = files.get(device);
         clientFiles.get(clientId).add(filePath);
       }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
@@ -81,23 +81,23 @@ public class RealMetaDataSchema extends MetaDataSchema {
 
     // Split into client And store Type
     for (int i = 0; i < deviceSchemaList.size(); i++) {
-      int clientId = i % config.getCLIENT_NUMBER();
+      int clientId = i % config.getDATA_CLIENT_NUMBER();
       DeviceSchema deviceSchema = deviceSchemaList.get(i);
-      if (!CLIENT_DATA_SCHEMA.containsKey(clientId)) {
-        CLIENT_DATA_SCHEMA.put(clientId, new ArrayList<>());
+      if (!DATA_CLIENT_DATA_SCHEMA.containsKey(clientId)) {
+        DATA_CLIENT_DATA_SCHEMA.put(clientId, new ArrayList<>());
       }
-      CLIENT_DATA_SCHEMA.get(clientId).add(deviceSchema);
+      DATA_CLIENT_DATA_SCHEMA.get(clientId).add(deviceSchema);
     }
 
     // Split data files into client
     List<List<String>> clientFiles = new ArrayList<>();
-    for (int i = 0; i < config.getCLIENT_NUMBER(); i++) {
+    for (int i = 0; i < config.getDATA_CLIENT_NUMBER(); i++) {
       clientFiles.add(new ArrayList<>());
     }
 
     for (int i = 0; i < files.size(); i++) {
       String filePath = files.get(i);
-      int clientId = i % config.getCLIENT_NUMBER();
+      int clientId = i % config.getDATA_CLIENT_NUMBER();
       clientFiles.get(clientId).add(filePath);
     }
     MetaUtil.setClientFiles(clientFiles);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
@@ -27,6 +27,7 @@ import cn.edu.tsinghua.iot.benchmark.schema.MetaDataSchema;
 import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
 import cn.edu.tsinghua.iot.benchmark.source.CSVSchemaReader;
 import cn.edu.tsinghua.iot.benchmark.source.SchemaReader;
+import cn.edu.tsinghua.iot.benchmark.utils.CommonAlgorithms;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,10 +58,10 @@ public class RealMetaDataSchema extends MetaDataSchema {
       return false;
     }
     // Load file from dataset
-    List<String> files = new ArrayList<>();
+    Map<String, String> files = new LinkedHashMap<>();
     getAllFiles(pathStr, files);
     LOGGER.info("Total files: {}", files.size());
-    Collections.sort(files);
+    //    Collections.sort(files);
 
     // Load sensor type from dataset
     Map<String, List<Sensor>> deviceSchemaMap = schemaReader.getDeviceSchemaList();
@@ -69,14 +70,19 @@ public class RealMetaDataSchema extends MetaDataSchema {
       String deviceName = device.getKey();
       List<Sensor> sensors = device.getValue();
       DeviceSchema deviceSchema =
-          new DeviceSchema(
-              MetaUtil.getGroupIdFromDeviceName(deviceName),
-              deviceName,
-              sensors,
-              MetaUtil.getTags(deviceName));
+          new DeviceSchema(deviceName, sensors, MetaUtil.getTags(deviceName));
       NAME_DATA_SCHEMA.put(deviceName, deviceSchema);
       GROUPS.add(deviceSchema.getGroup());
       deviceSchemaList.add(deviceSchema);
+    }
+
+    for (int i = 0; i < deviceSchemaList.size(); i++) {
+      int clientId = i % config.getSCHEMA_CLIENT_NUMBER();
+      DeviceSchema deviceSchema = deviceSchemaList.get(i);
+      if (!SCHEMA_CLIENT_DATA_SCHEMA.containsKey(clientId)) {
+        SCHEMA_CLIENT_DATA_SCHEMA.put(clientId, new ArrayList<>());
+      }
+      SCHEMA_CLIENT_DATA_SCHEMA.get(clientId).add(deviceSchema);
     }
 
     // Split into client And store Type
@@ -89,22 +95,30 @@ public class RealMetaDataSchema extends MetaDataSchema {
       DATA_CLIENT_DATA_SCHEMA.get(clientId).add(deviceSchema);
     }
 
-    // Split data files into client
+    // Split data files into data client
     List<List<String>> clientFiles = new ArrayList<>();
     for (int i = 0; i < config.getDATA_CLIENT_NUMBER(); i++) {
       clientFiles.add(new ArrayList<>());
     }
 
-    for (int i = 0; i < files.size(); i++) {
-      String filePath = files.get(i);
-      int clientId = i % config.getDATA_CLIENT_NUMBER();
-      clientFiles.get(clientId).add(filePath);
+    Map<Integer, Integer> deviceDistributionForDataClient =
+        CommonAlgorithms.distributeDevicesToClients(
+            config.getDEVICE_NUMBER(), config.getDATA_CLIENT_NUMBER());
+    List<Integer> deviceIds = MetaUtil.sortDeviceId(config, LOGGER);
+    int index = 0;
+    for (int clientId = 0; clientId < config.getDATA_CLIENT_NUMBER(); clientId++) {
+      int fileNumber = deviceDistributionForDataClient.get(clientId);
+      for (int fileId = 0; fileId < fileNumber; fileId++, index++) {
+        String device = "d_" + deviceIds.get(index);
+        String filePath = files.get(device);
+        clientFiles.get(clientId).add(filePath);
+      }
     }
     MetaUtil.setClientFiles(clientFiles);
     return true;
   }
 
-  private static void getAllFiles(String strPath, List<String> files) {
+  private static void getAllFiles(String strPath, Map<String, String> files) {
     File f = new File(strPath);
     if (f.isDirectory()) {
       File[] fs = f.listFiles();
@@ -116,7 +130,10 @@ public class RealMetaDataSchema extends MetaDataSchema {
     } else if (f.isFile()) {
       if (!f.getAbsolutePath().contains(Constants.SCHEMA_PATH)
           && !f.getAbsolutePath().contains(Constants.INFO_PATH)) {
-        files.add(f.getAbsolutePath());
+        String path = f.getAbsolutePath();
+        int lastIndexOf = path.lastIndexOf("\\");
+        String device = path.substring(path.lastIndexOf("\\", lastIndexOf - 1) + 1, lastIndexOf);
+        files.put(device, f.getAbsolutePath());
       }
     }
   }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchema.java
@@ -61,7 +61,6 @@ public class RealMetaDataSchema extends MetaDataSchema {
     Map<String, String> files = new LinkedHashMap<>();
     getAllFiles(pathStr, files);
     LOGGER.info("Total files: {}", files.size());
-    //    Collections.sort(files);
 
     // Load sensor type from dataset
     Map<String, List<Sensor>> deviceSchemaMap = schemaReader.getDeviceSchemaList();

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReader.java
@@ -76,12 +76,7 @@ public class CSVDataReader extends DataReader {
           for (int i = 1; i < items.length; i++) {
             sensors.add(stringToSensorMap.get(items[i]));
           }
-          deviceSchema =
-              new DeviceSchema(
-                  MetaUtil.getGroupIdFromDeviceName(deviceName),
-                  deviceName,
-                  sensors,
-                  MetaUtil.getTags(deviceName));
+          deviceSchema = new DeviceSchema(deviceName, sensors, MetaUtil.getTags(deviceName));
           firstLine = false;
           continue;
         }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVSchemaReader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVSchemaReader.java
@@ -28,7 +28,7 @@ public class CSVSchemaReader extends SchemaReader {
       LOGGER.error("Failed to find schema file in " + path.getFileName().toString());
       System.exit(0);
     }
-    Map<String, List<Sensor>> result = new HashMap<>();
+    Map<String, List<Sensor>> result = new LinkedHashMap<>();
     try {
       List<String> schemaLines = Files.readAllLines(path);
       for (String schemaLine : schemaLines) {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReader.java
@@ -85,12 +85,7 @@ public class CopyDataReader extends DataReader {
           for (int i = 1; i < items.length; i++) {
             sensors.add(stringToSensorMap.get(items[i]));
           }
-          deviceSchema =
-              new DeviceSchema(
-                  MetaUtil.getGroupIdFromDeviceName(deviceName),
-                  deviceName,
-                  sensors,
-                  MetaUtil.getTags(deviceName));
+          deviceSchema = new DeviceSchema(deviceName, sensors, MetaUtil.getTags(deviceName));
           firstLine = false;
           continue;
         }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/DataWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/DataWorkLoad.java
@@ -42,7 +42,7 @@ public abstract class DataWorkLoad implements IDataWorkLoad {
       return new RealDataWorkLoad(files);
     } else {
       if (config.isIS_CLIENT_BIND()) {
-        List<DeviceSchema> deviceSchemas = metaDataSchema.getDeviceSchemaByClientId(clientId);
+        List<DeviceSchema> deviceSchemas = metaDataSchema.getDeviceSchemaByDataClientId(clientId);
         return new SyntheticDataWorkLoad(deviceSchemas);
       } else {
         return SingletonWorkDataWorkLoad.getInstance();

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
@@ -42,7 +42,7 @@ public class SingletonWorkDataWorkLoad extends GenerateDataWorkLoad {
   private static SingletonWorkDataWorkLoad singletonWorkDataWorkLoad = null;
   private static final AtomicInteger sensorIndex = new AtomicInteger();
   private final AtomicLong insertLoop = new AtomicLong(0);
-  private static final List<Integer> deviceIds = MetaUtil.sortDeviceId(config, LOGGER);
+  private static final List<Integer> deviceIds = MetaUtil.sortDeviceId();
 
   private SingletonWorkDataWorkLoad() {
     if (config.isIS_OUT_OF_ORDER()) {

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/serialize/BatchSerializeTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/serialize/BatchSerializeTest.java
@@ -53,7 +53,7 @@ public class BatchSerializeTest {
     Map<String, String> tags = new HashMap<>();
     tags.put("tag1", "value1");
     tags.put("tag2", "value2");
-    DeviceSchema deviceSchema = new DeviceSchema(group, device, sensors, tags);
+    DeviceSchema deviceSchema = new DeviceSchema(device, sensors, tags);
     List<Record> records = new LinkedList<>();
     for (int i = 0; i < 12; i++) {
       records.add(buildRecord(i, 10));

--- a/iotdb-1.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb100/IoTDB.java
+++ b/iotdb-1.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb100/IoTDB.java
@@ -91,8 +91,9 @@ public class IoTDB implements IDatabase {
 
   protected static final Config config = ConfigDescriptor.getInstance().getConfig();
   protected static final CyclicBarrier templateBarrier =
-      new CyclicBarrier(config.getCLIENT_NUMBER());
-  protected static final CyclicBarrier schemaBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
+  protected static final CyclicBarrier schemaBarrier =
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   protected static Set<String> storageGroups = Collections.synchronizedSet(new HashSet<>());
   protected final String ROOT_SERIES_NAME;
   protected ExecutorService service;

--- a/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
+++ b/iotdb-1.1/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb110/IoTDB.java
@@ -95,10 +95,11 @@ public class IoTDB implements IDatabase {
 
   protected static final Config config = ConfigDescriptor.getInstance().getConfig();
   protected static final CyclicBarrier templateBarrier =
-      new CyclicBarrier(config.getCLIENT_NUMBER());
-  protected static final CyclicBarrier schemaBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
+  protected static final CyclicBarrier schemaBarrier =
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   protected static final CyclicBarrier activateTemplateBarrier =
-      new CyclicBarrier(config.getCLIENT_NUMBER());
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   protected static Set<String> storageGroups = Collections.synchronizedSet(new HashSet<>());
   protected final String ROOT_SERIES_NAME;
   protected ExecutorService service;

--- a/iotdb-1.3/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb130/IoTDB.java
+++ b/iotdb-1.3/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb130/IoTDB.java
@@ -95,10 +95,11 @@ public class IoTDB implements IDatabase {
 
   protected static final Config config = ConfigDescriptor.getInstance().getConfig();
   protected static final CyclicBarrier templateBarrier =
-      new CyclicBarrier(config.getCLIENT_NUMBER());
-  protected static final CyclicBarrier schemaBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
+  protected static final CyclicBarrier schemaBarrier =
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   protected static final CyclicBarrier activateTemplateBarrier =
-      new CyclicBarrier(config.getCLIENT_NUMBER());
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   protected static Set<String> storageGroups = Collections.synchronizedSet(new HashSet<>());
   protected final String ROOT_SERIES_NAME;
   protected ExecutorService service;

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/IoTDBModelStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/IoTDBModelStrategy.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
 
 public abstract class IoTDBModelStrategy {
   protected static final Config config = ConfigDescriptor.getInstance().getConfig();
@@ -49,6 +50,8 @@ public abstract class IoTDBModelStrategy {
   protected static String ROOT_SERIES_NAME;
   protected static int queryBaseOffset;
   protected static final Set<String> databases = new HashSet<>();
+  protected static final CyclicBarrier schemaBarrier =
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
 
   public IoTDBModelStrategy(DBConfig dbConfig) {
     this.dbConfig = dbConfig;

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
@@ -51,7 +51,8 @@ import java.util.concurrent.CyclicBarrier;
 public class TableStrategy extends IoTDBModelStrategy {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TableStrategy.class);
-  private static final CyclicBarrier schemaBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
+  private static final CyclicBarrier schemaBarrier =
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
 
   public TableStrategy(DBConfig dbConfig) {
     super(dbConfig);

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
@@ -46,13 +46,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CyclicBarrier;
 
 public class TableStrategy extends IoTDBModelStrategy {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TableStrategy.class);
-  private static final CyclicBarrier schemaBarrier =
-      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
 
   public TableStrategy(DBConfig dbConfig) {
     super(dbConfig);

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
@@ -63,8 +63,6 @@ public class TreeStrategy extends IoTDBModelStrategy {
   private final Random random = new Random(config.getDATA_SEED());
   private static final CyclicBarrier templateBarrier =
       new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
-  private static final CyclicBarrier schemaBarrier =
-      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   private static final CyclicBarrier activateTemplateBarrier =
       new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   private static final AtomicBoolean templateInit = new AtomicBoolean(false);

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
@@ -61,10 +61,12 @@ public class TreeStrategy extends IoTDBModelStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(TreeStrategy.class);
 
   private final Random random = new Random(config.getDATA_SEED());
-  private static final CyclicBarrier templateBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
-  private static final CyclicBarrier schemaBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
+  private static final CyclicBarrier templateBarrier =
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
+  private static final CyclicBarrier schemaBarrier =
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   private static final CyclicBarrier activateTemplateBarrier =
-      new CyclicBarrier(config.getCLIENT_NUMBER());
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   private static final AtomicBoolean templateInit = new AtomicBoolean(false);
 
   public TreeStrategy(DBConfig dbConfig) {

--- a/tdengine-3.0/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine3/TDengine.java
+++ b/tdengine-3.0/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine3/TDengine.java
@@ -63,7 +63,7 @@ public class TDengine implements IDatabase {
   private static final String TDENGINE_DRIVER = "com.taosdata.jdbc.TSDBDriver";
   private static final String TDENGINE_URL = "jdbc:TAOS://%s:%s/?user=%s&password=%s";
   protected static final CyclicBarrier superTableBarrier =
-      new CyclicBarrier(config.getCLIENT_NUMBER());
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
   private static final String USE_DB = "use %s";
 
   private static final String SUPER_TABLE_NAME = "device";

--- a/timescaledb-cluster/src/main/java/cn/edu/tsinghua/iot/benchmark/timescaledbCluster/TimescaleDB.java
+++ b/timescaledb-cluster/src/main/java/cn/edu/tsinghua/iot/benchmark/timescaledbCluster/TimescaleDB.java
@@ -72,7 +72,8 @@ public class TimescaleDB implements IDatabase {
       "SELECT create_distributed_hypertable('%s', 'time', 'location', replication_factor => %s, chunk_time_interval => 604800000);";
   private static final String dropTable = "DROP TABLE %s;";
   private static final AtomicBoolean schemaInit = new AtomicBoolean(false);
-  protected static final CyclicBarrier schemaBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
+  protected static final CyclicBarrier schemaBarrier =
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
 
   private static String tableName;
   private Connection connection;

--- a/timescaledb/src/main/java/cn/edu/tsinghua/iot/benchmark/timescaledb/TimescaleDB.java
+++ b/timescaledb/src/main/java/cn/edu/tsinghua/iot/benchmark/timescaledb/TimescaleDB.java
@@ -72,7 +72,8 @@ public class TimescaleDB implements IDatabase {
       "SELECT create_hypertable('%s', 'time', chunk_time_interval => 604800000);";
   private static final String dropTable = "DROP TABLE %s;";
   private static final AtomicBoolean schemaInit = new AtomicBoolean(false);
-  protected static final CyclicBarrier schemaBarrier = new CyclicBarrier(config.getCLIENT_NUMBER());
+  protected static final CyclicBarrier schemaBarrier =
+      new CyclicBarrier(config.getSCHEMA_CLIENT_NUMBER());
 
   private static String tableName;
   private Connection connection;


### PR DESCRIPTION
#### SCHEMA_CLIENT_NUMBER 控制 schema client
#### DATA_CLIENT_NUMBER 控制 data client
大多数改动是用上面的两个参数替换 CLIENT_NUMBER 。

1.之前用CLIENT_DATA_SCHEMA存储每个 client 负责的 deviceSchema。
现在用SCHEMA_CLIENT_DATA_SCHEMA存储每个 schemaclient 负责的 deviceSchema，DATA_CLIENT_DATA_SCHEMA存储每个 dataClient 负责的 deviceSchema；使用 CLIENT_DATA_SCHEMA 的方法也随之扩展为两个。

2.为了兼容参数 CLIENT_NUMBER，加载参数时会先加载 SCHEMA_CLIENT_NUMBER 与 DATA_CLIENT_NUMBER，然后加载 CLIENT_NUMBER 的值并赋值给 SCHEMA_CLIENT_NUMBER 与 DATA_CLIENT_NUMBER，用 CLIENT_NUMBER 的值去覆盖 SCHEMA_CLIENT_NUMBER 与 DATA_CLIENT_NUMBER 的默认值。

3.增加函数 distributeDevices 负责为每一个 client 分配 deviceSchema 。按照 deviceIds 分配。

4.verificationWriteMode 模式下是将文件（eg: bigBatch_0.tcsv）分配给每一个 client，之前是随机分配，改为按照 deviceIds的顺序排序；

5.deviceIds 进行了两次排序，第一次让属于同一个 database 的 deviceId 相邻，第二次让俗语同一个 table 的 deviceId 相邻，从而保证表模型下，分配给同一个 dataClient 的 device 是属于同一个 table 的，这样表模型下每个 data client 只需要执行一次 use database.
