### PR TITLE
 Corrected SQL generation logic to prevent parsing errors

### DIFF
--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/JDBCStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/JDBCStrategy.java
@@ -68,7 +68,7 @@ public class JDBCStrategy extends DMLStrategy {
       for (Record record : batch.getRecords()) {
         String sql =
             getInsertOneBatchSql(
-                batch.getDeviceSchema(), record.getTimestamp(), record.getRecordDataValue());
+                batch.getDeviceSchema(), record.getTimestamp(), record.getRecordDataValue(), devicePath);
         statement.addBatch(sql);
       }
       statement.executeBatch();
@@ -232,9 +232,9 @@ public class JDBCStrategy extends DMLStrategy {
   }
 
   private String getInsertOneBatchSql(
-      DeviceSchema deviceSchema, long timestamp, List<Object> values) {
+      DeviceSchema deviceSchema, long timestamp, List<Object> values, String devicePath) {
     StringBuilder builder = new StringBuilder("insert into ");
-    builder.append(deviceSchema.getDevicePath()).append("(timestamp");
+    builder.append(devicePath).append("(timestamp");
     for (Sensor sensor : deviceSchema.getSensors()) {
       builder.append(",").append(sensor.getName());
     }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/JDBCStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/JDBCStrategy.java
@@ -68,7 +68,10 @@ public class JDBCStrategy extends DMLStrategy {
       for (Record record : batch.getRecords()) {
         String sql =
             getInsertOneBatchSql(
-                batch.getDeviceSchema(), record.getTimestamp(), record.getRecordDataValue(), devicePath);
+                batch.getDeviceSchema(),
+                record.getTimestamp(),
+                record.getRecordDataValue(),
+                devicePath);
         statement.addBatch(sql);
       }
       statement.executeBatch();


### PR DESCRIPTION
## Cause: 
deviceSchema.getDevicePath() returns group.device, which lacks the “root.test” prefix.