### PR TITLE
The system shuts down automatically if the template creation fails.

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
@@ -89,7 +89,7 @@ public class SchemaClient implements Callable<Boolean> {
 
         // register
         try {
-          // When the return value is non-empty, the registerSchema is successful.
+          // When the return value is not null, the registerSchema is successful.
           result = (null != dbWrapper.registerSchema(deviceSchemas));
         } catch (TsdbException e) {
           LOGGER.error("Register {} schema failed because ", config.getNET_DEVICE(), e);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
@@ -22,6 +22,7 @@ package cn.edu.tsinghua.iot.benchmark.client;
 import cn.edu.tsinghua.iot.benchmark.conf.Config;
 import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
+import cn.edu.tsinghua.iot.benchmark.mode.BaseMode;
 import cn.edu.tsinghua.iot.benchmark.schema.MetaDataSchema;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
@@ -92,6 +93,7 @@ public class SchemaClient implements Runnable {
         } catch (TsdbException e) {
           LOGGER.error("Register {} schema failed because ", config.getNET_DEVICE(), e);
           result = false;
+          BaseMode.flag = false;
         }
       } catch (Exception e) {
         LOGGER.error("Unexpected error: ", e);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
@@ -89,6 +89,7 @@ public class SchemaClient implements Callable<Boolean> {
 
         // register
         try {
+          // When the return value is non-empty, the registerSchema is successful.
           result = (null != dbWrapper.registerSchema(deviceSchemas));
         } catch (TsdbException e) {
           LOGGER.error("Register {} schema failed because ", config.getNET_DEVICE(), e);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
@@ -32,10 +32,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 
-public class SchemaClient implements Runnable {
+public class SchemaClient implements Callable<Boolean> {
   private static final Logger LOGGER = LoggerFactory.getLogger(SchemaClient.class);
 
   protected static Config config = ConfigDescriptor.getInstance().getConfig();
@@ -77,7 +78,7 @@ public class SchemaClient implements Runnable {
   }
 
   @Override
-  public void run() {
+  public Boolean call() {
     try {
       try {
         if (dbWrapper != null) {
@@ -88,7 +89,7 @@ public class SchemaClient implements Runnable {
 
         // register
         try {
-          result = (null == dbWrapper.registerSchema(deviceSchemas));
+          result = (null != dbWrapper.registerSchema(deviceSchemas));
         } catch (TsdbException e) {
           LOGGER.error("Register {} schema failed because ", config.getNET_DEVICE(), e);
           result = false;
@@ -106,6 +107,7 @@ public class SchemaClient implements Runnable {
       }
     } finally {
       countDownLatch.countDown();
+      return result;
     }
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
@@ -93,7 +93,7 @@ public class SchemaClient implements Runnable {
         } catch (TsdbException e) {
           LOGGER.error("Register {} schema failed because ", config.getNET_DEVICE(), e);
           result = false;
-          BaseMode.flag = false;
+          BaseMode.stopAllSchemaClient = false;
         }
       } catch (Exception e) {
         LOGGER.error("Unexpected error: ", e);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/SchemaClient.java
@@ -22,7 +22,6 @@ package cn.edu.tsinghua.iot.benchmark.client;
 import cn.edu.tsinghua.iot.benchmark.conf.Config;
 import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
-import cn.edu.tsinghua.iot.benchmark.mode.BaseMode;
 import cn.edu.tsinghua.iot.benchmark.schema.MetaDataSchema;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
@@ -93,7 +92,6 @@ public class SchemaClient implements Runnable {
         } catch (TsdbException e) {
           LOGGER.error("Register {} schema failed because ", config.getNET_DEVICE(), e);
           result = false;
-          BaseMode.stopAllSchemaClient = false;
         }
       } catch (Exception e) {
         LOGGER.error("Unexpected error: ", e);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
@@ -66,6 +66,7 @@ public abstract class BaseMode {
   protected List<DataClient> dataClients = new ArrayList<>();
   protected List<SchemaClient> schemaClients = new ArrayList<>();
   protected Measurement baseModeMeasurement = new Measurement();
+  public static volatile boolean flag = true;
   protected long startTime = 0;
 
   protected abstract boolean preCheck();
@@ -184,6 +185,10 @@ public abstract class BaseMode {
     try {
       // wait for all dataClients finish test
       schemaDownLatch.await();
+      if (!flag) {
+        LOGGER.error("Registering schema failed!");
+        return false;
+      }
       schemaClients.stream()
           .map(SchemaClient::getMeasurement)
           .forEach(baseModeMeasurement::mergeCreateSchemaFinishTime);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
@@ -66,7 +66,7 @@ public abstract class BaseMode {
   protected List<DataClient> dataClients = new ArrayList<>();
   protected List<SchemaClient> schemaClients = new ArrayList<>();
   protected Measurement baseModeMeasurement = new Measurement();
-  public static volatile boolean stopAllSchemaClient = true;
+  public static volatile boolean stopAllSchemaClient = false;
   protected long startTime = 0;
 
   protected abstract boolean preCheck();
@@ -185,7 +185,7 @@ public abstract class BaseMode {
     try {
       // wait for all dataClients finish test
       schemaDownLatch.await();
-      if (!stopAllSchemaClient) {
+      if (isStopAllSchemaClient()) {
         LOGGER.error("Registering schema failed!");
         return false;
       }
@@ -265,5 +265,13 @@ public abstract class BaseMode {
     if (config.isCSV_OUTPUT()) {
       measurement.outputCSV();
     }
+  }
+
+  public static boolean isStopAllSchemaClient() {
+    return stopAllSchemaClient;
+  }
+
+  public static void setStopAllSchemaClient(boolean stopAllSchemaClient) {
+    BaseMode.stopAllSchemaClient = stopAllSchemaClient;
   }
 }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/mode/BaseMode.java
@@ -66,7 +66,7 @@ public abstract class BaseMode {
   protected List<DataClient> dataClients = new ArrayList<>();
   protected List<SchemaClient> schemaClients = new ArrayList<>();
   protected Measurement baseModeMeasurement = new Measurement();
-  public static volatile boolean flag = true;
+  public static volatile boolean stopAllSchemaClient = true;
   protected long startTime = 0;
 
   protected abstract boolean preCheck();
@@ -185,7 +185,7 @@ public abstract class BaseMode {
     try {
       // wait for all dataClients finish test
       schemaDownLatch.await();
-      if (!flag) {
+      if (!stopAllSchemaClient) {
         LOGGER.error("Registering schema failed!");
         return false;
       }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
@@ -19,7 +19,6 @@
 
 package cn.edu.tsinghua.iot.benchmark.iotdb200.ModelStrategy;
 
-import cn.edu.tsinghua.iot.benchmark.mode.BaseMode;
 import org.apache.iotdb.isession.template.Template;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
@@ -33,6 +32,7 @@ import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.iotdb200.IoTDB;
 import cn.edu.tsinghua.iot.benchmark.iotdb200.TimeseriesSchema;
 import cn.edu.tsinghua.iot.benchmark.iotdb200.utils.IoTDBUtils;
+import cn.edu.tsinghua.iot.benchmark.mode.BaseMode;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.TsdbException;

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
@@ -32,7 +32,6 @@ import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
 import cn.edu.tsinghua.iot.benchmark.iotdb200.IoTDB;
 import cn.edu.tsinghua.iot.benchmark.iotdb200.TimeseriesSchema;
 import cn.edu.tsinghua.iot.benchmark.iotdb200.utils.IoTDBUtils;
-import cn.edu.tsinghua.iot.benchmark.mode.BaseMode;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.TsdbException;

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
@@ -54,6 +54,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -88,7 +89,7 @@ public class TreeStrategy extends IoTDBModelStrategy {
         Session templateSession = new ArrayList<>(sessionListMap.keySet()).get(sessionIndex);
         registerTemplate(templateSession, template);
       }
-      templateBarrier.await();
+      templateBarrier.await(5, TimeUnit.SECONDS);
       for (Map.Entry<Session, List<TimeseriesSchema>> pair : sessionListMap.entrySet()) {
         registerDatabases(pair.getKey(), pair.getValue());
       }


### PR DESCRIPTION
### 问题
- 当注册元数据方法抛出异常后，bm 卡死不退出。这是由于抛出异常的线程少走了一次 CyclicBarrier 的 await() ，导致其他线程一直处于等待状态。

### 场景
将 device 均分给每个 schemaClient 创建，创建 template -> 创建 database -> 激活 template -> 创建时间序列，使用 template 元数据的流程存在顺序关系：
- 创建 template 只需一个线程执行一次即可，完成 template 创建后，其他线程再创建database；
- 激活 template 前要保证所有的 database 已被创建；
- 创建时间序列前，需要所有线程完成 template 的激活；
所以，此处使用 3 个 CyclicBarrier ：templateBarrier、schemaBarrier、activateTemplateBarrier。


### 解法
1. 在 basemode 下设置 volatile stopAllSchemaClient，默认为 false, 当有创建元数据方法抛出异常后在 catch 中将其改为 true；
2. 使用 try finally 保证不论方法是否正确执行，都会执行 await();
3. 在每个 await() 下加上对 stopAllSchemaClient 的检查，当为 true 时，提前结束方法，从而结束当前线程；

