### PR TITLE
IoTDB-2.0: Manipulating the database with sessionPool

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/DataClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/DataClient.java
@@ -125,7 +125,6 @@ public abstract class DataClient implements Runnable {
         taskProgress.setThreadName(Thread.currentThread().getName());
         // wait for that all dataClients start test simultaneously
         barrier.await();
-
         doTest();
       } catch (Exception e) {
         LOGGER.error("Unexpected error: ", e);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/progress/TaskProgress.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/progress/TaskProgress.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package cn.edu.tsinghua.iot.benchmark.client.progress;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/constant/ThreadName.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/constant/ThreadName.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package cn.edu.tsinghua.iot.benchmark.constant;
 
 import org.slf4j.Logger;
@@ -7,7 +26,7 @@ public enum ThreadName {
   // -------------------------- ClientService --------------------------
   DATA_CLIENT_THREAD("DataClientService"),
   SCHEMA_CLIENT_THREAD("SchemaClientService"),
-  DATA_CLIENT_EXECUTE_JOB("DataClientExecuteJob"),
+  EXECUTE_JOB("ExecuteJob"),
 
   // -------------------------- showService --------------------------
   SHOW_WORK_PROCESS("ShowWorkProgress"),

--- a/iotdb-1.3/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb130/IoTDB.java
+++ b/iotdb-1.3/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb130/IoTDB.java
@@ -122,7 +122,7 @@ public class IoTDB implements IDatabase {
         ioTDBConnection.init();
         this.service =
             Executors.newSingleThreadExecutor(
-                new NamedThreadFactory(ThreadName.DATA_CLIENT_EXECUTE_JOB.getName()));
+                new NamedThreadFactory(ThreadName.EXECUTE_JOB.getName()));
       } catch (Exception e) {
         throw new TsdbException(e);
       }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/JDBCStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/JDBCStrategy.java
@@ -206,7 +206,7 @@ public class JDBCStrategy extends DMLStrategy {
         ioTDBConnection.init();
         this.service =
             Executors.newSingleThreadExecutor(
-                new NamedThreadFactory(ThreadName.DATA_CLIENT_EXECUTE_JOB.getName()));
+                new NamedThreadFactory(ThreadName.EXECUTE_JOB.getName()));
       } catch (Exception e) {
         throw new TsdbException(e);
       }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/AbstractSessionPool.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/AbstractSessionPool.java
@@ -1,23 +1,4 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-package cn.edu.tsinghua.iot.benchmark.iotdb200.DMLStrategy;
+package cn.edu.tsinghua.iot.benchmark.iotdb200.DMLStrategy.SessionPool;
 
 import org.apache.iotdb.isession.SessionDataSet;
 import org.apache.iotdb.isession.template.Template;
@@ -35,15 +16,24 @@ import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.write.record.Tablet;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public abstract class SessionManager {
+public abstract class AbstractSessionPool {
   protected static final Config config = ConfigDescriptor.getInstance().getConfig();
   protected final DBConfig dbConfig;
 
-  public SessionManager(DBConfig dbConfig) {
+  public AbstractSessionPool(DBConfig dbConfig) {
     this.dbConfig = dbConfig;
+  }
+
+  protected List<String> getHostUrls() {
+    List<String> hostUrls = new ArrayList<>(dbConfig.getHOST().size());
+    for (int i = 0; i < dbConfig.getHOST().size(); i++) {
+      hostUrls.add(dbConfig.getHOST().get(i) + ":" + dbConfig.getPORT().get(i));
+    }
+    return hostUrls;
   }
 
   public abstract void executeNonQueryStatement(String sql)
@@ -55,7 +45,7 @@ public abstract class SessionManager {
   public abstract SessionDataSet executeQueryStatement(String sql, long timeoutInMs)
       throws TsdbException, IoTDBConnectionException, StatementExecutionException;
 
-  protected abstract void insertRecord(
+  public abstract void insertRecord(
       String deviceId,
       long time,
       List<String> measurements,
@@ -63,7 +53,7 @@ public abstract class SessionManager {
       List<Object> values)
       throws IoTDBConnectionException, StatementExecutionException;
 
-  protected abstract void insertRecords(
+  public abstract void insertRecords(
       List<String> deviceIds,
       List<Long> times,
       List<List<String>> measurementsList,
@@ -111,5 +101,4 @@ public abstract class SessionManager {
       List<Map<String, String>> attributesList,
       List<String> measurementAliasList)
       throws IoTDBConnectionException, StatementExecutionException;
-  // endregion
 }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/AbstractSessionPool.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/AbstractSessionPool.java
@@ -36,6 +36,7 @@ import org.apache.tsfile.write.record.Tablet;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -93,6 +94,9 @@ public abstract class AbstractSessionPool {
       throws IoTDBConnectionException, IOException, StatementExecutionException;
 
   public abstract void setStorageGroup(String storageGroup)
+      throws IoTDBConnectionException, StatementExecutionException;
+
+  public abstract void registerTable(HashMap<String, List<String>> tables)
       throws IoTDBConnectionException, StatementExecutionException;
 
   public abstract void setSchemaTemplate(String templateName, String prefixPath)

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/AbstractSessionPool.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/AbstractSessionPool.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package cn.edu.tsinghua.iot.benchmark.iotdb200.DMLStrategy.SessionPool;
 
 import org.apache.iotdb.isession.SessionDataSet;

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/TableSessionPoolWrapper.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/TableSessionPoolWrapper.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package cn.edu.tsinghua.iot.benchmark.iotdb200.DMLStrategy.SessionPool;
 
 import org.apache.iotdb.isession.ITableSession;
@@ -98,10 +117,7 @@ public class TableSessionPoolWrapper extends AbstractSessionPool {
   }
 
   @Override
-  public void open() {
-    // TODO sessionPool是否需要 open
-    // TableSession combines the build and open operations of the session
-  }
+  public void open() {}
 
   @Override
   public void close() throws TsdbException {

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/TableSessionPoolWrapper.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/TableSessionPoolWrapper.java
@@ -1,30 +1,12 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-package cn.edu.tsinghua.iot.benchmark.iotdb200.DMLStrategy;
+package cn.edu.tsinghua.iot.benchmark.iotdb200.DMLStrategy.SessionPool;
 
 import org.apache.iotdb.isession.ITableSession;
 import org.apache.iotdb.isession.SessionDataSet;
+import org.apache.iotdb.isession.pool.ITableSessionPool;
 import org.apache.iotdb.isession.template.Template;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
-import org.apache.iotdb.session.TableSessionBuilder;
+import org.apache.iotdb.session.pool.TableSessionPoolBuilder;
 
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
@@ -36,65 +18,76 @@ import org.apache.tsfile.write.record.Tablet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-public class TableSessionManager extends SessionManager {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TableSessionManager.class);
-  private final ITableSession tableSession;
+public class TableSessionPoolWrapper extends AbstractSessionPool {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableSessionPoolWrapper.class);
+  private final ITableSessionPool tableSessionPool;
   private boolean isFirstExecution = true;
 
-  public TableSessionManager(DBConfig dbConfig) throws IoTDBConnectionException {
+  public TableSessionPoolWrapper(DBConfig dbConfig, Integer maxSize) {
     super(dbConfig);
-    List<String> hostUrls = new ArrayList<>(dbConfig.getHOST().size());
-    for (int i = 0; i < dbConfig.getHOST().size(); i++) {
-      hostUrls.add(dbConfig.getHOST().get(i) + ":" + dbConfig.getPORT().get(i));
-    }
-    this.tableSession = builderTableSession(hostUrls);
+    tableSessionPool = builderTableSessionPool(getHostUrls(), maxSize);
+  }
+
+  private ITableSessionPool builderTableSessionPool(List<String> hostUrls, Integer maxSize) {
+    return new TableSessionPoolBuilder()
+        .nodeUrls(hostUrls)
+        .user(dbConfig.getUSERNAME())
+        .password(dbConfig.getPASSWORD())
+        .enableCompression(config.isENABLE_THRIFT_COMPRESSION())
+        .enableRedirection(true)
+        .enableAutoFetch(false)
+        .maxSize(maxSize)
+        .build();
   }
 
   @Override
   public void executeNonQueryStatement(String sql)
       throws IoTDBConnectionException, StatementExecutionException {
-    tableSession.executeNonQueryStatement(sql);
+    tableSessionPool.getSession().executeNonQueryStatement(sql);
   }
 
   @Override
   public SessionDataSet executeQueryStatement(String sql)
       throws IoTDBConnectionException, StatementExecutionException {
-    return tableSession.executeQueryStatement(sql);
+    return tableSessionPool.getSession().executeQueryStatement(sql);
   }
 
   @Override
   public SessionDataSet executeQueryStatement(String sql, long timeoutInMs)
-      throws IoTDBConnectionException, StatementExecutionException {
-    return tableSession.executeQueryStatement(sql, timeoutInMs);
+      throws TsdbException, IoTDBConnectionException, StatementExecutionException {
+    return tableSessionPool.getSession().executeQueryStatement(sql, timeoutInMs);
   }
 
   @Override
-  protected void insertRecord(
+  public void insertRecord(
       String deviceId,
       long time,
       List<String> measurements,
       List<TSDataType> types,
-      List<Object> values) {
+      List<Object> values)
+      throws IoTDBConnectionException, StatementExecutionException {
     throw new UnsupportedOperationException("TableSession does not implement this function");
   }
 
   @Override
-  protected void insertRecords(
+  public void insertRecords(
       List<String> deviceIds,
       List<Long> times,
       List<List<String>> measurementsList,
       List<List<TSDataType>> typesList,
-      List<List<Object>> valuesList) {
+      List<List<Object>> valuesList)
+      throws IoTDBConnectionException, StatementExecutionException {
     throw new UnsupportedOperationException("TableSession does not implement this function");
   }
 
   @Override
   public void insertTablet(Tablet tablet, DeviceSchema deviceSchema)
       throws IoTDBConnectionException, StatementExecutionException {
+    ITableSession tableSession = tableSessionPool.getSession();
     if (isFirstExecution) {
       StringBuilder sql = new StringBuilder();
       sql.append("use ").append(dbConfig.getDB_NAME()).append("_").append(deviceSchema.getGroup());
@@ -106,36 +99,41 @@ public class TableSessionManager extends SessionManager {
 
   @Override
   public void open() {
+    // TODO sessionPool是否需要 open
     // TableSession combines the build and open operations of the session
   }
 
   @Override
   public void close() throws TsdbException {
     try {
-      tableSession.close();
-    } catch (IoTDBConnectionException ioTDBConnectionException) {
+      tableSessionPool.close();
+    } catch (RuntimeException e) {
       LOGGER.error("Failed to close TableSession");
-      throw new TsdbException(ioTDBConnectionException);
+      throw new TsdbException(e);
     }
   }
 
   @Override
-  public void createSchemaTemplate(Template template) {
+  public void createSchemaTemplate(Template template)
+      throws IoTDBConnectionException, IOException, StatementExecutionException {
     throw new UnsupportedOperationException("TableSession does not implement this function");
   }
 
   @Override
-  public void setStorageGroup(String storageGroup) {
+  public void setStorageGroup(String storageGroup)
+      throws IoTDBConnectionException, StatementExecutionException {
     throw new UnsupportedOperationException("TableSession does not implement this function");
   }
 
   @Override
-  public void setSchemaTemplate(String templateName, String prefixPath) {
+  public void setSchemaTemplate(String templateName, String prefixPath)
+      throws IoTDBConnectionException, StatementExecutionException {
     throw new UnsupportedOperationException("TableSession does not implement this function");
   }
 
   @Override
-  public void createTimeseriesUsingSchemaTemplate(List<String> devicePathList) {
+  public void createTimeseriesUsingSchemaTemplate(List<String> devicePathList)
+      throws IoTDBConnectionException, StatementExecutionException {
     throw new UnsupportedOperationException("TableSession does not implement this function");
   }
 
@@ -146,7 +144,8 @@ public class TableSessionManager extends SessionManager {
       List<TSDataType> dataTypes,
       List<TSEncoding> encodings,
       List<CompressionType> compressors,
-      List<String> measurementAliasList) {
+      List<String> measurementAliasList)
+      throws IoTDBConnectionException, StatementExecutionException {
     throw new UnsupportedOperationException("TableSession does not implement this function");
   }
 
@@ -159,17 +158,8 @@ public class TableSessionManager extends SessionManager {
       List<Map<String, String>> propsList,
       List<Map<String, String>> tagsList,
       List<Map<String, String>> attributesList,
-      List<String> measurementAliasList) {
+      List<String> measurementAliasList)
+      throws IoTDBConnectionException, StatementExecutionException {
     throw new UnsupportedOperationException("TableSession does not implement this function");
-  }
-
-  private ITableSession builderTableSession(List<String> hostUrls) throws IoTDBConnectionException {
-    return new TableSessionBuilder()
-        .nodeUrls(hostUrls)
-        .username(dbConfig.getUSERNAME())
-        .password(dbConfig.getPASSWORD())
-        .enableCompression(config.isENABLE_THRIFT_COMPRESSION())
-        .enableRedirection(true)
-        .build();
   }
 }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/TreeSessionPoolWrapper.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionPool/TreeSessionPoolWrapper.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package cn.edu.tsinghua.iot.benchmark.iotdb200.DMLStrategy.SessionPool;
 
 import org.apache.iotdb.isession.SessionDataSet;
@@ -41,6 +60,7 @@ public class TreeSessionPoolWrapper extends AbstractSessionPool {
         .enableAutoFetch(false)
         .version(Version.V_1_0)
         .maxSize(maxSize)
+        .waitToGetSessionTimeoutInMs(config.getREAD_OPERATION_TIMEOUT_MS())
         .build();
   }
 
@@ -53,24 +73,16 @@ public class TreeSessionPoolWrapper extends AbstractSessionPool {
   @Override
   public SessionDataSet executeQueryStatement(String sql)
       throws IoTDBConnectionException, StatementExecutionException {
-    try (SessionDataSetWrapper sessionDataSetWrapper = sessionPool.executeQueryStatement(sql)) {
-      return sessionDataSetWrapper.getSessionDataSet();
-    } catch (RuntimeException e) {
-      // TODO 异常处理
-      throw new RuntimeException(e);
-    }
+    SessionDataSetWrapper sessionDataSetWrapper = sessionPool.executeQueryStatement(sql);
+    return sessionDataSetWrapper.getSessionDataSet();
   }
 
   @Override
   public SessionDataSet executeQueryStatement(String sql, long timeoutInMs)
       throws TsdbException, IoTDBConnectionException, StatementExecutionException {
-    try (SessionDataSetWrapper sessionDataSetWrapper =
-        sessionPool.executeQueryStatement(sql, timeoutInMs)) {
-      return sessionDataSetWrapper.getSessionDataSet();
-    } catch (RuntimeException e) {
-      // TODO 异常处理
-      throw new RuntimeException(e);
-    }
+    SessionDataSetWrapper sessionDataSetWrapper =
+        sessionPool.executeQueryStatement(sql, timeoutInMs);
+    return sessionDataSetWrapper.getSessionDataSet();
   }
 
   @Override
@@ -127,7 +139,6 @@ public class TreeSessionPoolWrapper extends AbstractSessionPool {
     sessionPool.createSchemaTemplate(template);
   }
 
-  // TODO: 改名
   @Override
   public void setStorageGroup(String storageGroup)
       throws IoTDBConnectionException, StatementExecutionException {

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/SessionStrategy.java
@@ -476,10 +476,8 @@ public class SessionStrategy extends DMLStrategy {
 
   @Override
   public void init() {
-    // TODO clean 数据、SchemaClient、DataClient 都用到了这里，因此名字写死不合适。
     this.service =
-        Executors.newSingleThreadExecutor(
-            new NamedThreadFactory(ThreadName.DATA_CLIENT_EXECUTE_JOB.getName()));
+        Executors.newSingleThreadExecutor(new NamedThreadFactory(ThreadName.EXECUTE_JOB.getName()));
   }
 
   @Override

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/IoTDB.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/IoTDB.java
@@ -138,7 +138,6 @@ public class IoTDB implements IDatabase {
    */
   @Override
   public Double registerSchema(List<DeviceSchema> schemaList) throws TsdbException {
-    // TODO 此处存在问题，没必要对 Map 进行 for 循环，他是sessionPool
     AbstractSessionPool sessionPoolForSchemaClient =
         SessionStrategy.getSessionPool(dbConfig, config.getSCHEMA_CLIENT_NUMBER());
     long start = System.nanoTime();

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/IoTDBModelStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/IoTDBModelStrategy.java
@@ -27,7 +27,7 @@ import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.entity.Batch.IBatch;
 import cn.edu.tsinghua.iot.benchmark.entity.Record;
 import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
-import cn.edu.tsinghua.iot.benchmark.iotdb200.DMLStrategy.SessionManager;
+import cn.edu.tsinghua.iot.benchmark.iotdb200.DMLStrategy.SessionPool.AbstractSessionPool;
 import cn.edu.tsinghua.iot.benchmark.iotdb200.IoTDB;
 import cn.edu.tsinghua.iot.benchmark.iotdb200.TimeseriesSchema;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
@@ -59,7 +59,8 @@ public abstract class IoTDBModelStrategy {
   }
 
   public abstract void registerSchema(
-      Map<SessionManager, List<TimeseriesSchema>> sessionListMap, List<DeviceSchema> schemaList)
+      Map<AbstractSessionPool, List<TimeseriesSchema>> sessionPoolListMap,
+      List<DeviceSchema> schemaList)
       throws TsdbException;
 
   // region select
@@ -141,7 +142,7 @@ public abstract class IoTDBModelStrategy {
   }
 
   public abstract void registerDatabases(
-      SessionManager metaSession, List<TimeseriesSchema> schemaList) throws TsdbException;
+      AbstractSessionPool sessionPool, List<TimeseriesSchema> schemaList) throws TsdbException;
 
   public abstract Tablet createTablet(
       String insertTargetName,
@@ -154,11 +155,7 @@ public abstract class IoTDBModelStrategy {
   public abstract void addIDColumnIfNecessary(
       List<Tablet.ColumnCategory> columnTypes, List<Sensor> sensors, IBatch batch);
 
-  public abstract void sessionInsertImpl(
-      SessionManager sessionManager, Tablet tablet, DeviceSchema deviceSchema)
-      throws IoTDBConnectionException, StatementExecutionException;
-
-  public abstract void sessionCleanupImpl(SessionManager sessionManager)
+  public abstract void sessionCleanupImpl(AbstractSessionPool sessionPool)
       throws IoTDBConnectionException, StatementExecutionException;
 
   // endregion

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
@@ -139,13 +139,7 @@ public class TableStrategy extends IoTDBModelStrategy {
                 dbConfig.getDB_NAME() + "_" + deviceSchema.getGroup(), k -> new ArrayList<>())
             .add(builder.toString());
       }
-
-      for (Map.Entry<String, List<String>> database : tables.entrySet()) {
-        sessionPool.executeNonQueryStatement("use " + database.getKey());
-        for (String table : database.getValue()) {
-          sessionPool.executeNonQueryStatement(table);
-        }
-      }
+      sessionPool.registerTable(tables);
     } catch (Exception e) {
       handleRegisterException(e);
     }


### PR DESCRIPTION
现象：session 需要通过一次通信将 database 调整为目标 database。
表模型写入需要两次session通信，一次修改database，一次insertTablet，比树模型多一次通信，影响 iot-benchmark 对两个模型写入性能的对比。此 PR 使用反射减少通信。
此PR暂时关闭。