### PR TITLE
Opt for schema create of table model

### DIFF
--- a/iotdb-2.0/pom.xml
+++ b/iotdb-2.0/pom.xml
@@ -47,7 +47,7 @@
   <properties>
     <!-- This was the last version to support Java 8 -->
     <logback.version>1.3.15</logback.version>
-    <iotdb.version>2.0.3</iotdb.version>
+    <iotdb.version>2.0.4</iotdb.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <gson.version>2.10.1</gson.version>
   </properties>

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
@@ -44,7 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -71,7 +70,7 @@ public class TableStrategy extends IoTDBModelStrategy {
       }
       schemaBarrier.await();
       for (Map.Entry<SessionManager, List<TimeseriesSchema>> pair : sessionListMap.entrySet()) {
-        registerTable(pair.getKey(), pair.getValue());
+        registerTable(pair.getKey(), schemaList);
       }
     } catch (Exception e) {
       throw new TsdbException(e);
@@ -94,50 +93,57 @@ public class TableStrategy extends IoTDBModelStrategy {
     }
   }
 
-  private void registerTable(SessionManager metaSession, List<TimeseriesSchema> timeseriesSchemas)
+  private void registerTable(SessionManager metaSession, List<DeviceSchema> deviceSchemas)
       throws TsdbException {
     try {
-      HashMap<String, List<String>> tables = new HashMap<>();
-      for (TimeseriesSchema schema : timeseriesSchemas) {
-        DeviceSchema deviceSchema = schema.getDeviceSchema();
-        StringBuilder builder = new StringBuilder();
-        builder.append("create table if not exists ").append(deviceSchema.getTable()).append("(");
-        // 1.Generate SQL for registering table
-        for (int i = 0; i < deviceSchema.getSensors().size(); i++) {
-          if (i != 0) builder.append(", ");
-          builder
-              .append(deviceSchema.getSensors().get(i).getName())
-              .append(" ")
-              .append(deviceSchema.getSensors().get(i).getSensorType())
-              .append(" ")
-              .append(deviceSchema.getSensors().get(i).getColumnCategory());
-        }
-        builder
-            .append(", device_id")
-            .append(" ")
-            .append(SensorType.STRING)
-            .append(" ")
-            .append(ColumnCategory.TAG);
-        for (String key : deviceSchema.getTags().keySet()) {
-          builder
-              .append(", ")
-              .append(key)
-              .append(" ")
-              .append(SensorType.STRING)
-              .append(" ")
-              .append(ColumnCategory.TAG);
-        }
-        builder.append(")");
+      // dbName -> tableName -> create table sql
+      HashMap<String, Map<String, String>> tables = new HashMap<>();
+      for (DeviceSchema deviceSchema : deviceSchemas) {
         tables
             .computeIfAbsent(
-                dbConfig.getDB_NAME() + "_" + deviceSchema.getGroup(), k -> new ArrayList<>())
-            .add(builder.toString());
+                dbConfig.getDB_NAME() + "_" + deviceSchema.getGroup(), k -> new HashMap<>())
+            .computeIfAbsent(
+                deviceSchema.getTable(),
+                k -> {
+                  StringBuilder builder = new StringBuilder();
+                  builder
+                      .append("create table if not exists ")
+                      .append(deviceSchema.getTable())
+                      .append("(");
+                  // 1.Generate SQL for registering table
+                  for (int i = 0; i < deviceSchema.getSensors().size(); i++) {
+                    if (i != 0) builder.append(", ");
+                    builder
+                        .append(deviceSchema.getSensors().get(i).getName())
+                        .append(" ")
+                        .append(deviceSchema.getSensors().get(i).getSensorType())
+                        .append(" ")
+                        .append(deviceSchema.getSensors().get(i).getColumnCategory());
+                  }
+                  builder
+                      .append(", device_id")
+                      .append(" ")
+                      .append(SensorType.STRING)
+                      .append(" ")
+                      .append(ColumnCategory.TAG);
+                  for (String key : deviceSchema.getTags().keySet()) {
+                    builder
+                        .append(", ")
+                        .append(key)
+                        .append(" ")
+                        .append(SensorType.STRING)
+                        .append(" ")
+                        .append(ColumnCategory.TAG);
+                  }
+                  builder.append(")");
+                  return builder.toString();
+                });
       }
 
       // 2.Registration table
-      for (Map.Entry<String, List<String>> database : tables.entrySet()) {
+      for (Map.Entry<String, Map<String, String>> database : tables.entrySet()) {
         metaSession.executeNonQueryStatement("use " + database.getKey());
-        for (String table : database.getValue()) {
+        for (String table : database.getValue().values()) {
           metaSession.executeNonQueryStatement(table);
         }
       }


### PR DESCRIPTION
in table model, previously, we will call `ceate table` multi times corresponding to sensor number).

Currently, we will call `ceate table` one time for one table.

Previous time cost(about 6 min)
<img width="3224" height="548" alt="image" src="https://github.com/user-attachments/assets/4aab6b0e-25a2-4f69-bd30-8812ce4fcddb" />

current time cost(about 1 s)
<img width="3150" height="412" alt="image" src="https://github.com/user-attachments/assets/00545a1e-3b87-48bb-b31a-128c2f940df2" />

bm config:
```
IoTDB_DIALECT_MODE=table
LOOP=17
DEVICE_NUMBER=10000
SENSOR_NUMBER=1
INSERT_DATATYPE_PROPORTION=0:0:0:1:0:0:0:0:0:0
IS_OUT_OF_ORDER=false
BATCH_SIZE_PER_WRITE=10000
DEVICE_NUM_PER_WRITE=1
SCHEMA_CLIENT_NUMBER=1
```