### PR TITLE
Relax TableMode client constraint from per-table to per-database binding

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -821,12 +821,14 @@ public class ConfigDescriptor {
       LOGGER.error("DEVICE_NUM_PER_WRITE must be greater than 0");
       return false;
     }
-    // tableMode
+    // tableMode: each client must be bound to a single database to avoid frequent database
+    // switching
     if (config.getIoTDB_DIALECT_MODE() == SQLDialect.TABLE
-        && config.getDATA_CLIENT_NUMBER() % config.getIoTDB_TABLE_NUMBER() != 0) {
+        && config.hasWrite()
+        && config.getDATA_CLIENT_NUMBER() % config.getGROUP_NUMBER() != 0) {
       LOGGER.error(
-          "TableMode must ensure that a client only writes to one table. Therefore, a client only switches database once.\n"
-              + "please make DATA_CLIENT_NUMBER % IoTDB_TABLE_NUMBER == 0");
+          "TableMode must ensure that a client only writes to one database.\n"
+              + "please make DATA_CLIENT_NUMBER % GROUP_NUMBER == 0");
       return false;
     }
     if (dnw == 1) {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/schema/MetaUtil.java
@@ -4,6 +4,7 @@ import cn.edu.tsinghua.iot.benchmark.conf.Config;
 import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.conf.Constants;
 import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.SQLDialect;
 import cn.edu.tsinghua.iot.benchmark.exception.WorkloadException;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
 import cn.edu.tsinghua.iot.benchmark.utils.CommonAlgorithms;
@@ -128,6 +129,27 @@ public class MetaUtil {
         deviceIndex++;
       }
       clientDataSchema.put(clientId, deviceSchemasList);
+    }
+    if (config.getIoTDB_DIALECT_MODE() == SQLDialect.TABLE && config.hasWrite()) {
+      for (Map.Entry<Integer, List<DeviceSchema>> entry : clientDataSchema.entrySet()) {
+        List<DeviceSchema> schemas = entry.getValue();
+        if (schemas.isEmpty()) {
+          continue;
+        }
+        String expectedGroup = schemas.get(0).getGroup();
+        for (DeviceSchema schema : schemas) {
+          if (!expectedGroup.equals(schema.getGroup())) {
+            LOGGER.error(
+                "Client {} has devices across multiple databases ({} and {}). "
+                    + "In TableMode, each client must be bound to a single database.",
+                entry.getKey(),
+                expectedGroup,
+                schema.getGroup());
+            throw new RuntimeException(
+                "Device distribution violated single-database-per-client constraint in TableMode");
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Relax TableMode config validation from `DATA_CLIENT_NUMBER % IoTDB_TABLE_NUMBER == 0` to `DATA_CLIENT_NUMBER % GROUP_NUMBER == 0`, allowing one client to write to multiple tables within the same database
- Skip the constraint entirely when write proportion is 0 (query-only scenarios need no client-database binding)
- Add explicit post-distribution assertion in `MetaUtil.distributeDevices()` to verify the single-database-per-client invariant at runtime, preventing silent breakage if device distribution logic changes in the future

## Test plan
- [ ] Verify `DATA_CLIENT_NUMBER=10, IoTDB_TABLE_NUMBER=50, GROUP_NUMBER=1` starts successfully (previously failed)
- [ ] Verify `DATA_CLIENT_NUMBER=10, IoTDB_TABLE_NUMBER=50, GROUP_NUMBER=3` correctly rejects (10 % 3 != 0)
- [ ] Verify query-only scenario (write proportion = 0) bypasses the constraint regardless of client/table numbers
- [ ] Verify write correctness: data lands in the correct tables when one client writes to multiple tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)