### PR TITLE
Update IoTDB version to 2.0.8 for iotdb-2.0 module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,22 +79,22 @@ jobs:
           repository: 'thulab/iot-benchmark'
           ref: 'master'
           fetch-depth: 0
-      # checkout iotdb
-      - name: Checkout iotdb
-        uses: actions/checkout@v4
-        if: ${{ matrix.release_db == 'iotdb-2.0' }}
-        with:
-          path: iotdb
-          repository: 'apache/iotdb'
-          ref: 'master'
-          fetch-depth: 0
-      # compile iotdb
-      - name: Compile iotdb
-        if: ${{ matrix.release_db == 'iotdb-2.0' }}
-        run: |
-          cd ${{ github.workspace }}/iotdb
-          mvn clean
-          mvn install -DskipTests -am -pl iotdb-client/session
+      # checkout & compile iotdb — no longer needed since iotdb-2.0 now
+      # uses released version 2.0.8 from Maven Central
+      # - name: Checkout iotdb
+      #   uses: actions/checkout@v4
+      #   if: ${{ matrix.release_db == 'iotdb-2.0' }}
+      #   with:
+      #     path: iotdb
+      #     repository: 'apache/iotdb'
+      #     ref: 'master'
+      #     fetch-depth: 0
+      # - name: Compile iotdb
+      #   if: ${{ matrix.release_db == 'iotdb-2.0' }}
+      #   run: |
+      #     cd ${{ github.workspace }}/iotdb
+      #     mvn clean
+      #     mvn install -DskipTests -am -pl iotdb-client/session
       # compile benchmark
       - name: Build benchmark binaries
         id: compile-benchmark

--- a/iotdb-2.0/pom.xml
+++ b/iotdb-2.0/pom.xml
@@ -47,7 +47,7 @@
   <properties>
     <!-- This was the last version to support Java 8 -->
     <logback.version>1.3.15</logback.version>
-    <iotdb.version>2.0.6-SNAPSHOT</iotdb.version>
+    <iotdb.version>2.0.8</iotdb.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <gson.version>2.10.1</gson.version>
   </properties>


### PR DESCRIPTION
## Summary
- 将 `iotdb-2.0` 模块的 IoTDB 依赖从 `2.0.6-SNAPSHOT` 更新为 `2.0.8`（正式版）
- `2.0.6-SNAPSHOT` 从未发布到 Apache Snapshot 仓库，导致 CI 从 2026-04-23 起持续构建失败
- `2.0.8` 已在 Maven Central 上发布（`iotdb-session` 和 `iotdb-jdbc` 均可用）

## Root cause
commit `6d3310ad`（Support insert object by tablet）于 2026-04-23 合入 master，将版本从 `2.0.5-250801-SNAPSHOT`（Apache Snapshot 仓库有）改为 `2.0.6-SNAPSHOT`（不存在），导致 `compile (8, iotdb-2.0)` job 失败。

## Test plan
- [ ] 验证 CI `compile (8, iotdb-2.0)` job 构建成功
- [ ] 验证 iotdb-session 和 iotdb-jdbc 2.0.8 依赖正确解析