### PR TITLE
Add INTERVAL_BETWEEN_WRITE_BATCH for per-batch write interval

### DIFF
--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -241,14 +241,40 @@
 # 时间戳间隔，即生成的数据两个时间戳之间的固定长度(如果定长生成)，非正常速率
 # POINT_STEP=5000
 
-# 操作最小执行间隔：若当前操作耗时大于该间隔则马上执行下一个操作，否则等待 (OP_MIN_INTERVAL-实际执行时间) ms
+# 操作最小执行间隔（ms）：作用在每个 loop 结束后（一个 loop = 一个 operation）
+# 对于写入操作，一个 loop 会把该线程负责的所有设备都写一遍
+# 若 loop 耗时 < OP_MIN_INTERVAL，则等待剩余时间；若已超过则立即执行下一个 loop
 # 如果为0，则参数不生效；如果为-1，则其值和POINT_STEP一致
+#
+#   Thread-0:
+#   ┌── Loop 0 ─────────────────────────────┐
+#   │ 写 D0 → 写 D1 → ... → 写 D(N/M-1)    │→ 等待至 OP_MIN_INTERVAL
+#   └───────────────────────────────────────┘
+#   ┌── Loop 1 ─────────────────────────────┐
+#   │ 写 D0 → 写 D1 → ... → 写 D(N/M-1)    │→ 等待至 OP_MIN_INTERVAL
+#   └───────────────────────────────────────┘
+#
 # OP_MIN_INTERVAL=0
 
 # 是否随机选取操作最小执行间隔：
 # 如果为true，每次操作最小执行间隔的取值为 [0,OP_MIN_INTERVAL)
 # 如果为false，每次操作最小执行间隔的取值为 OP_MIN_INTERVAL
 # OP_MIN_INTERVAL_RANDOM=false
+
+# 每次写入请求的最小执行间隔（ms）：作用在每个 batch 写入之后
+# 与 OP_MIN_INTERVAL 不同，该参数让写入负载在时间上分布更均匀
+# 若单次 batch 写入耗时 < INTERVAL_BETWEEN_WRITE_BATCH，则等待剩余时间；若已超过则立即执行下一次写入
+# 默认值为0，即不等待
+#
+#   Thread-0:
+#   ┌── Loop 0 ───────────────────────────────────────────────────────────────┐
+#   │ 写 D0 → 等待至间隔 → 写 D1 → 等待至间隔 → ... → 写 D(N/M-1) → 等待至间隔 │
+#   └─────────────────────────────────────────────────────────────────────────┘
+#
+# 两个参数可同时生效：loop 内每个 batch 之间等待 INTERVAL_BETWEEN_WRITE_BATCH，
+# loop 结束后再等待 OP_MIN_INTERVAL
+#
+# INTERVAL_BETWEEN_WRITE_BATCH=0
 
 # 时间戳精度，均支持ms，只有IoTDB和InfluxDB支持us
 # TIMESTAMP_PRECISION=ms

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/generate/GenerateDataMixClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/client/generate/GenerateDataMixClient.java
@@ -154,9 +154,23 @@ public class GenerateDataMixClient extends GenerateBaseClient {
           if (isStop.get()) {
             return true;
           }
+          long batchStart = 0;
+          if (config.getINTERVAL_BETWEEN_WRITE_BATCH() > 0) {
+            batchStart = System.currentTimeMillis();
+          }
           IBatch batch = dataWorkLoad.getOneBatch();
           if (checkBatch(batch)) {
             dbWrapper.insertOneBatchWithCheck(batch);
+          }
+          if (config.getINTERVAL_BETWEEN_WRITE_BATCH() > 0) {
+            long elapsed = System.currentTimeMillis() - batchStart;
+            if (elapsed < config.getINTERVAL_BETWEEN_WRITE_BATCH()) {
+              try {
+                Thread.sleep(config.getINTERVAL_BETWEEN_WRITE_BATCH() - elapsed);
+              } catch (InterruptedException e) {
+                LOGGER.error("Wait between write batch failed because ", e);
+              }
+            }
           }
         }
       }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
@@ -350,6 +350,9 @@ public class Config {
   /** Whether to randomly select the minimum execution interval of the operation */
   private boolean OP_MIN_INTERVAL_RANDOM = false;
 
+  /** The interval between each write batch in ms, 0 means no interval */
+  private long INTERVAL_BETWEEN_WRITE_BATCH = 0;
+
   /** The max time for writing in ms */
   private int WRITE_OPERATION_TIMEOUT_MS = 120000;
 
@@ -1310,6 +1313,14 @@ public class Config {
     this.OP_MIN_INTERVAL_RANDOM = OP_MIN_INTERVAL_RANDOM;
   }
 
+  public long getINTERVAL_BETWEEN_WRITE_BATCH() {
+    return INTERVAL_BETWEEN_WRITE_BATCH;
+  }
+
+  public void setINTERVAL_BETWEEN_WRITE_BATCH(long INTERVAL_BETWEEN_WRITE_BATCH) {
+    this.INTERVAL_BETWEEN_WRITE_BATCH = INTERVAL_BETWEEN_WRITE_BATCH;
+  }
+
   public int getWRITE_OPERATION_TIMEOUT_MS() {
     return WRITE_OPERATION_TIMEOUT_MS;
   }
@@ -2042,6 +2053,8 @@ public class Config {
     configProperties.addProperty("Data Amount", "OP_MIN_INTERVAL", this.OP_MIN_INTERVAL);
     configProperties.addProperty(
         "Data Amount", "OP_MIN_INTERVAL_RANDOM", this.OP_MIN_INTERVAL_RANDOM);
+    configProperties.addProperty(
+        "Data Amount", "INTERVAL_BETWEEN_WRITE_BATCH", this.INTERVAL_BETWEEN_WRITE_BATCH);
     configProperties.addProperty(
         "Data Amount", "INSERT_DATATYPE_PROPORTION", this.INSERT_DATATYPE_PROPORTION);
     configProperties.addProperty(

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -417,6 +417,11 @@ public class ConfigDescriptor {
             Boolean.parseBoolean(
                 properties.getProperty(
                     "OP_MIN_INTERVAL_RANDOM", config.isOP_MIN_INTERVAL_RANDOM() + "")));
+        config.setINTERVAL_BETWEEN_WRITE_BATCH(
+            Long.parseLong(
+                properties.getProperty(
+                    "INTERVAL_BETWEEN_WRITE_BATCH",
+                    config.getINTERVAL_BETWEEN_WRITE_BATCH() + "")));
         config.setWRITE_OPERATION_TIMEOUT_MS(
             Integer.parseInt(
                 properties.getProperty(


### PR DESCRIPTION
## Summary
- `OP_MIN_INTERVAL` 的 sleep 作用在整个 loop 结束后（一个 loop 写完所有设备），而非每次 batch 写入之后，导致写入负载不均匀
- 新增 `INTERVAL_BETWEEN_WRITE_BATCH` 参数，控制每次 batch 写入的最小间隔，使写入负载在时间上分布更均匀
- 两个参数可同时生效：loop 内每个 batch 之间等待 `INTERVAL_BETWEEN_WRITE_BATCH`，loop 结束后再等待 `OP_MIN_INTERVAL`
- 优化了 `config.properties` 中两个参数的注释说明，增加了 ASCII 图示

## Test plan
- [ ] 设置 `INTERVAL_BETWEEN_WRITE_BATCH=0`（默认），验证行为与原有逻辑一致
- [ ] 设置 `INTERVAL_BETWEEN_WRITE_BATCH=100`，验证每次 batch 写入间隔不小于 100ms
- [ ] 同时设置 `OP_MIN_INTERVAL` 和 `INTERVAL_BETWEEN_WRITE_BATCH`，验证两者同时生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)