### PR TITLE
Add time column config and writable view for table model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+IoT Benchmark is a Java benchmarking tool for evaluating time-series and real-time databases in Industrial IoT scenarios. It supports 15+ databases (IoTDB, InfluxDB, TimescaleDB, TDengine, QuestDB, etc.) via a pluggable module architecture.
+
+## Build Commands
+
+```bash
+# Build all modules (skip tests)
+mvn clean package -Dmaven.test.skip=true
+
+# Build a specific DB module only
+mvn clean package -pl iotdb-2.0 -am -Dmaven.test.skip=true
+
+# Run tests
+mvn test
+
+# Run a single test class
+mvn test -pl core -Dtest=OperationControllerTest
+
+# Format check (Spotless, Google Java Format)
+mvn spotless:check
+
+# Auto-fix formatting
+mvn spotless:apply
+```
+
+Spotless runs automatically during `validate` phase. On JDK <= 11, spotless is skipped by default (profile `.java-11-below`).
+
+## Running a Benchmark
+
+After building, the distributable is at `<module>/target/iot-benchmark-<module>/iot-benchmark-<module>/`:
+
+```bash
+cd iotdb-2.0/target/iot-benchmark-iotdb-2.0/iot-benchmark-iotdb-2.0
+# Edit conf/config.properties, then:
+./benchmark.sh
+# Or with custom config and heap:
+./benchmark.sh -cf conf -heapsize 1G -maxheapsize 2G
+```
+
+The main class is `cn.edu.tsinghua.iot.benchmark.App`. Config is loaded from `configuration/conf/config.properties` (or the path passed via `-cf`).
+
+## Architecture
+
+### Multi-Module Maven Structure
+
+- **`core`** — Framework: config loading, mode orchestration, client threading, workload generation, measurement aggregation, the `IDatabase` interface. All DB modules depend on core.
+- **DB modules** (`iotdb-2.0`, `iotdb-1.3`, `influxdb`, `influxdb-2.0`, `timescaledb`, `tdengine`, etc.) — Each implements `IDatabase` for a specific database. Each module packages into a standalone distributable via `maven-assembly-plugin`.
+
+### Execution Flow
+
+```
+App.main()
+  → ConfigDescriptor (singleton) loads config.properties
+  → Selects BaseMode subclass based on BENCHMARK_WORK_MODE
+  → BaseMode.run()
+    → SchemaClient threads register schemas (CyclicBarrier sync)
+    → DataClient threads execute workload (read/write mix)
+      → OperationController selects operation type per OPERATION_PROPORTION
+      → DBWrapper delegates to IDatabase implementation
+      → Measurement collects latency/throughput metrics
+    → Aggregate and output results
+```
+
+### Key Abstractions
+
+- **`IDatabase`** (`core/.../tsdb/IDatabase.java`) — Contract all DB adapters implement: `init()`, `registerSchema()`, `insertOneBatch()`, plus ~12 query methods (precise, range, aggregation, group-by, latest-point, etc.).
+- **`DBFactory`** (`core/.../tsdb/DBFactory.java`) — Instantiates DB implementations by reflection. Maps `DBSwitch` enum values to class names defined in `Constants.java`.
+- **`BaseMode`** (`core/.../mode/BaseMode.java`) — Template method orchestrating schema registration → data client execution → measurement aggregation. Subclasses: `TestWithDefaultPathMode`, `GenerateDataMode`, `VerificationWriteMode`, `VerificationQueryMode`.
+- **`DataClient`** (`core/.../client/DataClient.java`) — Abstract Runnable, one per thread. Subclasses: `GenerateDataMixClient` (mixed read/write), `GenerateDataWriteClient`, `RealDataSetWriteClient`, etc.
+- **`Config`** (`core/.../conf/Config.java`) — 100+ parameters. `ConfigDescriptor` loads them from `config.properties` via reflection.
+- **`Measurement`** (`core/.../measurement/Measurement.java`) — Per-client metrics using TDigest for percentile latency. Merged across clients at end of run.
+
+### Adding a New Database Adapter
+
+1. Create a new Maven module with `core` as dependency.
+2. Implement `IDatabase` interface.
+3. Add the class name constant to `Constants.java`.
+4. Add the `DBSwitch` mapping in `DBFactory.java`.
+5. Add the module to root `pom.xml` `<modules>`.
+6. Add assembly descriptor at `src/assembly/assembly.xml` (copy from existing module).
+
+### IoTDB 2.0 Module Structure (representative)
+
+The `iotdb-2.0` module uses a strategy pattern:
+- **`IoTDB.java`** — Main `IDatabase` implementation, delegates to model and DML strategies.
+- **`ModelStrategy/`** — `TreeStrategy` and `TableStrategy` for different IoTDB SQL dialects (`IoTDB_DIALECT_MODE=tree|table`).
+- **`DMLStrategy/`** — `JDBCStrategy` and `SessionStrategy` for different insert modes (SESSION_BY_TABLET, SESSION_BY_RECORD, JDBC).
+
+## Configuration
+
+Main config file: `configuration/conf/config.properties`
+
+Key parameters:
+- `DB_SWITCH` — Database + version + insert mode (e.g., `IoTDB-200-SESSION_BY_TABLET`)
+- `IoTDB_DIALECT_MODE` — `tree` or `table` (IoTDB 2.0 only)
+- `BENCHMARK_WORK_MODE` — `testWithDefaultPath`, `generateDataMode`, `verificationWriteMode`, `verificationQueryMode`
+- `OPERATION_PROPORTION` — Colon-separated ratios for operation types (write:preciseQuery:rangeQuery:...)
+- `DEVICE_NUMBER`, `SENSOR_NUMBER`, `LOOP`, `BATCH_SIZE_PER_WRITE` — Workload scale
+- `HOST`, `PORT`, `USERNAME`, `PASSWORD` — Database connection
+- `DATA_CLIENT_NUMBER`, `SCHEMA_CLIENT_NUMBER` — Concurrency
+
+## Code Style
+
+- Java 8 source level
+- Google Java Format enforced by Spotless
+- Import order: `org.apache.iotdb`, default, `javax`, `java`, static
+- UNIX line endings
+
+## Adding a New Config Parameter
+
+When adding a new configuration parameter, must complete **all three steps**:
+
+1. **`Config.java`** — 添加字段、getter/setter
+2. **`ConfigDescriptor.java`** — 在 `loadProps()` 中从 properties 读取并 set 到 config（否则配置文件中的值不会生效）
+3. **`configuration/conf/config.properties`** — 添加注释说明和默认值示例

--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -11,6 +11,12 @@
 # sql_dialect等于tree时，要满足：device数量 >= database数量
 # IoTDB_DIALECT_MODE=tree
 
+# 表模型中时间列的名字，默认为time
+# IoTDB_TABLE_TIME_COLUMN=time
+
+# 表模型是否创建并使用可写视图，开启后会在建表后创建可写视图，后续读写都针对视图进行
+# IoTDB_TABLE_WRITABLE_VIEW=false
+
 # 主机列表，如果有多个主机则使用英文逗号进行分割
 # HOST=127.0.0.1
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
@@ -284,6 +284,12 @@ public class Config {
   /** The number of storage group, must less than or equal to number of devices */
   private int GROUP_NUMBER = 1;
 
+  /** The name of time column in table model */
+  private String IoTDB_TABLE_TIME_COLUMN = "time";
+
+  /** Whether to create and use writable views in table model */
+  private boolean IoTDB_TABLE_WRITABLE_VIEW = false;
+
   /** The number of table, In the tree model, it is equal to group_number */
   private int IoTDB_TABLE_NUMBER = 1;
 
@@ -1199,6 +1205,22 @@ public class Config {
 
   public void setGROUP_NUMBER(int GROUP_NUMBER) {
     this.GROUP_NUMBER = GROUP_NUMBER;
+  }
+
+  public String getIoTDB_TABLE_TIME_COLUMN() {
+    return IoTDB_TABLE_TIME_COLUMN;
+  }
+
+  public void setIoTDB_TABLE_TIME_COLUMN(String ioTDB_TABLE_TIME_COLUMN) {
+    IoTDB_TABLE_TIME_COLUMN = ioTDB_TABLE_TIME_COLUMN;
+  }
+
+  public boolean isIoTDB_TABLE_WRITABLE_VIEW() {
+    return IoTDB_TABLE_WRITABLE_VIEW;
+  }
+
+  public void setIoTDB_TABLE_WRITABLE_VIEW(boolean ioTDB_TABLE_WRITABLE_VIEW) {
+    IoTDB_TABLE_WRITABLE_VIEW = ioTDB_TABLE_WRITABLE_VIEW;
   }
 
   public int getIoTDB_TABLE_NUMBER() {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -348,6 +348,13 @@ public class ConfigDescriptor {
         config.setIoTDB_TABLE_NUMBER(
             Integer.parseInt(
                 properties.getProperty("IoTDB_TABLE_NUMBER", config.getIoTDB_TABLE_NUMBER() + "")));
+        config.setIoTDB_TABLE_TIME_COLUMN(
+            properties.getProperty("IoTDB_TABLE_TIME_COLUMN", config.getIoTDB_TABLE_TIME_COLUMN()));
+        config.setIoTDB_TABLE_WRITABLE_VIEW(
+            Boolean.parseBoolean(
+                properties.getProperty(
+                    "IoTDB_TABLE_WRITABLE_VIEW",
+                    String.valueOf(config.isIoTDB_TABLE_WRITABLE_VIEW()))));
 
         config.setIOTDB_SESSION_POOL_SIZE(
             Integer.parseInt(

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
@@ -145,6 +145,22 @@ public class TableStrategy extends IoTDBModelStrategy {
           metaSession.executeNonQueryStatement(table);
         }
       }
+
+      // 3.Create writable views if enabled
+      if (config.isIoTDB_TABLE_WRITABLE_VIEW()) {
+        for (Map.Entry<String, Map<String, String>> database : tables.entrySet()) {
+          metaSession.executeNonQueryStatement("use " + database.getKey());
+          for (String tableName : database.getValue().keySet()) {
+            String viewSql =
+                "create writable view "
+                    + tableName
+                    + "_v as select * from "
+                    + tableName
+                    + " with (schema_cascade=true)";
+            metaSession.executeNonQueryStatement(viewSql);
+          }
+        }
+      }
     } catch (Exception e) {
       handleRegisterException(e);
     }
@@ -155,7 +171,7 @@ public class TableStrategy extends IoTDBModelStrategy {
   @Override
   public String selectTimeColumnIfNecessary() {
     if (config.getBENCHMARK_WORK_MODE() == BenchmarkMode.VERIFICATION_QUERY) {
-      return "time, ";
+      return config.getIoTDB_TABLE_TIME_COLUMN() + ", ";
     } else {
       return "";
     }
@@ -172,12 +188,16 @@ public class TableStrategy extends IoTDBModelStrategy {
         .append("_")
         .append(devices.get(0).getGroup())
         .append(".")
-        .append(devices.get(0).getTable());
+        .append(devices.get(0).getTable())
+        .append(getViewSuffix());
   }
 
   @Override
   public void addOrderByTimeDesc(StringBuilder builder) {
-    builder.append(" ORDER BY device_id, time desc");
+    builder
+        .append(" ORDER BY device_id, ")
+        .append(config.getIoTDB_TABLE_TIME_COLUMN())
+        .append(" desc");
   }
 
   @Override
@@ -218,7 +238,8 @@ public class TableStrategy extends IoTDBModelStrategy {
         .append(" date_bin(")
         .append(groupByQuery.getGranularity())
         .append("ms, ")
-        .append("time), ")
+        .append(config.getIoTDB_TABLE_TIME_COLUMN())
+        .append("), ")
         .append(
             getAggFunForGroupByQuery(
                 groupByQuery.getDeviceSchema().get(0).getSensors(), groupByQuery.getAggFun()));
@@ -234,13 +255,17 @@ public class TableStrategy extends IoTDBModelStrategy {
     builder
         .append(" group by device_id, date_bin(")
         .append(groupByQuery.getGranularity())
-        .append("ms, time)");
+        .append("ms, ")
+        .append(config.getIoTDB_TABLE_TIME_COLUMN())
+        .append(")");
     // ORDER BY
     if (addOrderBy) {
       builder
           .append(" order by device_id, date_bin(")
           .append(groupByQuery.getGranularity())
-          .append("ms, time) desc");
+          .append("ms, ")
+          .append(config.getIoTDB_TABLE_TIME_COLUMN())
+          .append(") desc");
     }
     return builder.toString();
   }
@@ -254,7 +279,9 @@ public class TableStrategy extends IoTDBModelStrategy {
   public void addPreciseQueryWhereClause(
       String strTime, List<DeviceSchema> deviceSchemas, StringBuilder builder) {
     builder
-        .append(" WHERE time = ")
+        .append(" WHERE ")
+        .append(config.getIoTDB_TABLE_TIME_COLUMN())
+        .append(" = ")
         .append(strTime)
         .append(" AND ")
         .append(getDeviceIDColumn(deviceSchemas));
@@ -311,10 +338,18 @@ public class TableStrategy extends IoTDBModelStrategy {
   @Override
   public String getLatestPointQuerySql(List<DeviceSchema> devices) {
     StringBuilder builder = new StringBuilder();
-    builder.append("SELECT device_id, last(time)");
+    builder
+        .append("SELECT device_id, last(")
+        .append(config.getIoTDB_TABLE_TIME_COLUMN())
+        .append(")");
     List<Sensor> querySensors = devices.get(0).getSensors();
     for (int i = 0; i < querySensors.size(); i++) {
-      builder.append(", last_by(").append(querySensors.get(i).getName()).append(", time)");
+      builder
+          .append(", last_by(")
+          .append(querySensors.get(i).getName())
+          .append(", ")
+          .append(config.getIoTDB_TABLE_TIME_COLUMN())
+          .append(")");
     }
     addFromClause(devices, builder);
     addWhereValueClauseIfNecessary(devices, builder);
@@ -351,11 +386,17 @@ public class TableStrategy extends IoTDBModelStrategy {
       List<Record> records,
       Map<Long, List<Object>> recordMap,
       DeviceSchema deviceSchema) {
-    sql.append(" WHERE (time = ").append(records.get(0).getTimestamp());
+    sql.append(" WHERE (")
+        .append(config.getIoTDB_TABLE_TIME_COLUMN())
+        .append(" = ")
+        .append(records.get(0).getTimestamp());
     recordMap.put(records.get(0).getTimestamp(), records.get(0).getRecordDataValue());
     for (int i = 1; i < records.size(); i++) {
       Record record = records.get(i);
-      sql.append(" or time = ").append(record.getTimestamp());
+      sql.append(" or ")
+          .append(config.getIoTDB_TABLE_TIME_COLUMN())
+          .append(" = ")
+          .append(record.getTimestamp());
       recordMap.put(record.getTimestamp(), record.getRecordDataValue());
     }
     sql.append(" ) AND device_id = '").append(deviceSchema.getDevice()).append("'");
@@ -369,6 +410,21 @@ public class TableStrategy extends IoTDBModelStrategy {
             .append("'");
       }
     }
+  }
+
+  @Override
+  protected String getTimeWhereClause(long start, long end) {
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append(" ")
+        .append(config.getIoTDB_TABLE_TIME_COLUMN())
+        .append(" >= ")
+        .append(String.valueOf(start))
+        .append(" AND ")
+        .append(config.getIoTDB_TABLE_TIME_COLUMN())
+        .append(" <= ")
+        .append(String.valueOf(end));
+    return builder.toString();
   }
 
   @Override
@@ -411,6 +467,7 @@ public class TableStrategy extends IoTDBModelStrategy {
         + deviceSchema.getGroup()
         + "."
         + deviceSchema.getTable()
+        + getViewSuffix()
         + " where device_id = '"
         + deviceSchema.getDevice()
         + "'";
@@ -424,7 +481,10 @@ public class TableStrategy extends IoTDBModelStrategy {
         + deviceSchema.getGroup()
         + "."
         + deviceSchema.getTable()
-        + " order by time desc limit 1";
+        + getViewSuffix()
+        + " order by "
+        + config.getIoTDB_TABLE_TIME_COLUMN()
+        + " desc limit 1";
   }
 
   @Override
@@ -435,7 +495,10 @@ public class TableStrategy extends IoTDBModelStrategy {
         + deviceSchema.getGroup()
         + "."
         + deviceSchema.getTable()
-        + " order by time limit 1";
+        + getViewSuffix()
+        + " order by "
+        + config.getIoTDB_TABLE_TIME_COLUMN()
+        + " limit 1";
   }
 
   // endregion
@@ -458,7 +521,14 @@ public class TableStrategy extends IoTDBModelStrategy {
 
   @Override
   public String getInsertTargetName(DeviceSchema schema) {
+    if (config.isIoTDB_TABLE_WRITABLE_VIEW()) {
+      return schema.getTable() + "_v";
+    }
     return schema.getTable();
+  }
+
+  private String getViewSuffix() {
+    return config.isIoTDB_TABLE_WRITABLE_VIEW() ? "_v" : "";
   }
 
   @Override
@@ -549,7 +619,7 @@ public class TableStrategy extends IoTDBModelStrategy {
       case Constants.LAST_BY:
       case Constants.MAX_BY:
       case Constants.MIN_BY:
-        return "time, ";
+        return config.getIoTDB_TABLE_TIME_COLUMN() + ", ";
       default:
         return "";
     }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TableStrategy.java
@@ -108,6 +108,11 @@ public class TableStrategy extends IoTDBModelStrategy {
                       .append("create table if not exists ")
                       .append(deviceSchema.getTable())
                       .append("(");
+                  // 0.Add time column if customized
+                  String timeColumn = config.getIoTDB_TABLE_TIME_COLUMN();
+                  if (!"time".equals(timeColumn)) {
+                    builder.append(timeColumn).append(" TIMESTAMP TIME, ");
+                  }
                   // 1.Generate SQL for registering table
                   for (int i = 0; i < deviceSchema.getSensors().size(); i++) {
                     if (i != 0) builder.append(", ");


### PR DESCRIPTION
## 概述

为 IoTDB 2.0 表模型新增两个配置参数：

1. **IoTDB_TABLE_TIME_COLUMN** — 自定义表模型中时间列的名字（默认 `time`）
2. **IoTDB_TABLE_WRITABLE_VIEW** — 是否创建并使用可写视图（默认 `false`）

## 详细说明

### IoTDB_TABLE_TIME_COLUMN

允许用户指定表模型 SQL 中时间列的名称。所有查询（精确查询、范围查询、聚合查询、分组查询、最新点查询等）和排序子句中的时间列都会使用该配置值。

### IoTDB_TABLE_WRITABLE_VIEW

开启后，schema 注册阶段会在建表完成后，为每个表创建一个可写视图（视图名 = 表名 + `_v`）。后续所有的写入和查询操作都会针对可写视图进行，而非直接操作原始表。

创建视图的 SQL 示例：
```sql
CREATE WRITABLE VIEW table_0_v AS SELECT * FROM table_0 WITH (schema_cascade=true)
```

## 配置示例

```properties
# 指定表模型时间列名称，默认为 time
IoTDB_TABLE_TIME_COLUMN=time

# 开启可写视图，建表后自动创建可写视图，读写都针对视图进行
IoTDB_TABLE_WRITABLE_VIEW=true
```

## 执行流程变化

开启 `IoTDB_TABLE_WRITABLE_VIEW=true` 后：

1. **Schema 阶段**: CREATE DATABASE → CREATE TABLE → CREATE WRITABLE VIEW (新增)
2. **写入阶段**: Tablet 写入目标从 `table_0` 变为 `table_0_v`
3. **查询阶段**: FROM 子句从 `db_g_0.table_0` 变为 `db_g_0.table_0_v`

## 修改文件

- `core/.../conf/Config.java` — 新增配置字段及 getter/setter
- `iotdb-2.0/.../ModelStrategy/TableStrategy.java` — 可写视图创建逻辑、查询/写入目标路由、时间列名替换
- `configuration/conf/config.properties` — 配置说明文档