### PR TITLE
ci(core): 在 push/PR 上运行 core 单元测试

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -1,0 +1,31 @@
+name: core-unit-test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  core-unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          path: iot-benchmark
+      - name: Set java 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 8
+      - name: run core unit tests
+        run: |
+          cd ${{ github.workspace }}/iot-benchmark
+          mvn -B test -pl core
+      - name: upload jacoco report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-core
+          path: iot-benchmark/core/target/site/jacoco/

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -23,9 +23,3 @@ jobs:
         run: |
           cd ${{ github.workspace }}/iot-benchmark
           mvn -B test -pl core
-      - name: upload jacoco report
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: jacoco-core
-          path: iot-benchmark/core/target/site/jacoco/

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -116,24 +116,23 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
-        <executions>
-          <execution>
-            <id>prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>report</id>
-            <phase>test</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.4</version>
+        <configuration>
+          <!--
+            Tests trigger ConfigDescriptor, which resolves config.properties and
+            function.xml relative to "benchmark-conf" (default: configuration/conf).
+            Surefire forks with workingDirectory=core/, where these files don't
+            exist, so Config.initInnerFunction() hits a missing function.xml and
+            calls System.exit(0) (crashing the fork). Point benchmark-conf at the
+            repo-root config dir so the files resolve. The root config.properties
+            is fully commented out, so config stays at defaults.
+          -->
+          <systemPropertyVariables>
+            <benchmark-conf>${project.parent.basedir}/configuration/conf</benchmark-conf>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -114,7 +114,28 @@
     </dependency>
   </dependencies>
   <build>
-
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.12</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/client/OperationControllerTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/client/OperationControllerTest.java
@@ -42,7 +42,7 @@ public class OperationControllerTest {
 
   @Test
   public void testGetNextOperationType() {
-    config.setOPERATION_PROPORTION("1:0:0:0:0:0:0:0:0:0:0");
+    config.setOPERATION_PROPORTION("1:0:0:0:0:0:0:0:0:0:0:0:0");
     OperationController operationController = new OperationController(0);
 
     int loop = 10000;
@@ -50,7 +50,7 @@ public class OperationControllerTest {
       Assert.assertEquals(Operation.INGESTION, operationController.getNextOperationType());
     }
 
-    config.setOPERATION_PROPORTION("0:1:0:0:0:0:0:0:0:0:0");
+    config.setOPERATION_PROPORTION("0:1:0:0:0:0:0:0:0:0:0:0:0");
     operationController = new OperationController(0);
     for (int i = 0; i < loop; i++) {
       assertEquals(Operation.PRECISE_QUERY, operationController.getNextOperationType());


### PR DESCRIPTION
## 内容
构建 / CI 改动，无业务代码改动。

- 新增 `.github/workflows/core-test.yml`：在 push 与 Pull Request 上运行 `mvn test -pl core`。
- `core/pom.xml`：配置 surefire 的 `benchmark-conf` 指向 repo 根的配置目录，使 `ConfigDescriptor` 能找到 `function.xml`/`config.properties`。surefire fork 的工作目录是 `core/`，其中没有这些文件，会导致 `Config.initInnerFunction()` 调用 `System.exit(0)` 把 fork 杀掉（"forked VM terminated without properly saying goodbye"）。
- 修复 `OperationControllerTest` 中过时的 `OPERATION_PROPORTION`（11 → 13 个值），以匹配当前 normal operation 数量。

## 说明
基于 `master` 的独立分支。建议优先合并，使后续各分支的单元测试能在 CI 上自动运行。

> 注：原方案附带的 JaCoCo 覆盖率报告已移除，本 PR 只保留单元测试运行。