### PR TITLE
fix: 用 SLF4J 日志替换 e.printStackTrace()

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
@@ -568,7 +568,7 @@ public class Config {
       Unmarshaller unmarshaller = context.createUnmarshaller();
       xml = (FunctionXml) unmarshaller.unmarshal(input);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to init inner function from function.xml", e);
       System.exit(0);
     }
     List<FunctionParam> xmlFuctions = xml.getFunctions();

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -596,7 +596,7 @@ public class ConfigDescriptor {
                     "IS_RECORD_CURRENT_REALLY_TIME",
                     config.isIS_RECORD_CURRENT_REALLY_TIME() + "")));
       } catch (IOException e) {
-        e.printStackTrace();
+        LOGGER.error("Failed to load config file", e);
       }
       try {
         inputStream.close();

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/extern/CSVSchemaWriter.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/extern/CSVSchemaWriter.java
@@ -54,7 +54,7 @@ public class CSVSchemaWriter extends SchemaWriter {
                     try {
                       Files.delete(subPath);
                     } catch (IOException e) {
-                      e.printStackTrace();
+                      LOGGER.error("Failed to delete {}", subPath, e);
                     }
                   });
         }
@@ -81,11 +81,9 @@ public class CSVSchemaWriter extends SchemaWriter {
           infoPath, config.toInfoText().getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
       return true;
     } catch (IOException ioException) {
-      ioException.printStackTrace();
       LOGGER.error(
-          "Failed to generate Schema. Please check whether "
-              + config.getFILE_PATH()
-              + " is empty.");
+          "Failed to generate Schema. Please check whether " + config.getFILE_PATH() + " is empty.",
+          ioException);
       return false;
     }
   }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReader.java
@@ -121,8 +121,7 @@ public class CSVDataReader extends DataReader {
         records.add(record);
       }
     } catch (Exception exception) {
-      exception.printStackTrace();
-      LOGGER.error("Failed to read file:" + exception.getMessage());
+      LOGGER.error("Failed to read file", exception);
     }
     return new Batch(deviceSchema, records);
   }

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReader.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReader.java
@@ -128,8 +128,7 @@ public class CopyDataReader extends DataReader {
         records.add(record);
       }
     } catch (Exception exception) {
-      exception.printStackTrace();
-      LOGGER.error("Failed to read file:" + exception.getMessage());
+      LOGGER.error("Failed to read file", exception);
     }
     batch = new Batch(deviceSchema, records);
     deltaTimeStamp = curtimestamp - begin;

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/DBFactory.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/DBFactory.java
@@ -22,6 +22,8 @@ package cn.edu.tsinghua.iot.benchmark.tsdb;
 import cn.edu.tsinghua.iot.benchmark.conf.Config;
 import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
 import cn.edu.tsinghua.iot.benchmark.conf.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -29,6 +31,7 @@ import java.sql.SQLException;
 
 public class DBFactory {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(DBFactory.class);
   private static final Config config = ConfigDescriptor.getInstance().getConfig();
 
   public DBFactory() {}
@@ -142,7 +145,7 @@ public class DBFactory {
         | ClassNotFoundException
         | NoSuchMethodException
         | InvocationTargetException e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to instantiate database {}", dbConfig.getDB_SWITCH(), e);
     }
     throw new SQLException("init database " + dbConfig.getDB_SWITCH() + " failed");
   }

--- a/influxdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/influxdb2/HttpRequestUtil.java
+++ b/influxdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/influxdb2/HttpRequestUtil.java
@@ -8,10 +8,13 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 
 public class HttpRequestUtil {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequestUtil.class);
   private static final Config config = ConfigDescriptor.getInstance().getConfig();
 
   public static int writeData(String url, String body, String contentType, String token)
@@ -41,7 +44,7 @@ public class HttpRequestUtil {
       httpResponse = httpClient.execute(httpPost);
       responseCode = httpResponse.getStatusLine().getStatusCode();
     } catch (Exception var) {
-      var.printStackTrace();
+      LOGGER.error("Failed to write data to InfluxDB via HTTP", var);
       throw var;
     } finally {
       if (httpResponse != null) {

--- a/influxdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/influxdb2/InfluxDB.java
+++ b/influxdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/influxdb2/InfluxDB.java
@@ -432,7 +432,7 @@ public class InfluxDB implements IDatabase {
           Status status = executeQueryAndGetStatus(sql);
           result += status.getQueryResultPointNum();
         } catch (Exception e) {
-          e.printStackTrace();
+          LOGGER.error("Failed to execute aggRangeValueQuery", e);
         }
       }
     }

--- a/iotdb-1.3/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb130/IoTDB.java
+++ b/iotdb-1.3/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb130/IoTDB.java
@@ -254,7 +254,7 @@ public class IoTDB implements IDatabase {
       metaSession.createSchemaTemplate(template);
     } catch (StatementExecutionException e) {
       // do nothing
-      e.printStackTrace();
+      LOGGER.error("Failed to create schema template", e);
     }
   }
 
@@ -292,7 +292,7 @@ public class IoTDB implements IDatabase {
               .collect(Collectors.toList());
       metaSession.createTimeseriesUsingSchemaTemplate(devicePaths);
     } catch (Throwable t) {
-      t.printStackTrace();
+      LOGGER.error("Failed to activate schema template", t);
     }
   }
 

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/ModelStrategy/TreeStrategy.java
@@ -187,7 +187,7 @@ public class TreeStrategy extends IoTDBModelStrategy {
               .collect(Collectors.toList());
       metaSession.createTimeseriesUsingSchemaTemplate(devicePaths);
     } catch (Throwable t) {
-      t.printStackTrace();
+      LOGGER.error("Failed to activate schema template", t);
     }
   }
 

--- a/kairosdb/src/main/java/cn/edu/tsinghua/iot/benchmark/kairosdb/KairosDB.java
+++ b/kairosdb/src/main/java/cn/edu/tsinghua/iot/benchmark/kairosdb/KairosDB.java
@@ -80,7 +80,7 @@ public class KairosDB implements IDatabase {
       client =
           new HttpClient("http://" + dbConfig.getHOST().get(0) + ":" + dbConfig.getPORT().get(0));
     } catch (MalformedURLException e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to init KairosDB client due to malformed URL", e);
       throw new TsdbException(
           "Init KairosDB client failed, the url is "
               + dbConfig.getHOST()

--- a/mssqlserver/src/main/java/cn.edu.tsinghua.iotdb.benchmark.mssqlserver/MsSQLServerDB.java
+++ b/mssqlserver/src/main/java/cn.edu.tsinghua.iotdb.benchmark.mssqlserver/MsSQLServerDB.java
@@ -122,8 +122,7 @@ public class MsSQLServerDB implements IDatabase {
         }
       }
     } catch (Exception e) {
-      e.printStackTrace();
-      LOGGER.warn("Connect Error!");
+      LOGGER.warn("Connect Error!", e);
       throw new TsdbException("Connect Error!", e);
     }
   }
@@ -311,8 +310,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("preciseQuery Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -339,8 +337,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("rangeQuery Error!");
+      LOGGER.error("rangeQuery Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -368,8 +365,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("valueRangeQuery Error!");
+      LOGGER.error("valueRangeQuery Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -400,8 +396,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("aggRangeQuery Error!");
+      LOGGER.error("aggRangeQuery Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -425,8 +420,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("aggValueQuery Error!");
+      LOGGER.error("aggValueQuery Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -454,8 +448,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("aggRangeValueQuery Error!");
+      LOGGER.error("aggRangeValueQuery Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -482,8 +475,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("groupByQuery Error!");
+      LOGGER.error("groupByQuery Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -508,8 +500,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("latestPointQuery Error!");
+      LOGGER.error("latestPointQuery Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -536,8 +527,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("rangeQueryOrderByDesc Error!");
+      LOGGER.error("rangeQueryOrderByDesc Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -565,8 +555,7 @@ public class MsSQLServerDB implements IDatabase {
       }
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("valueRangeQueryOrderByDesc Error!");
+      LOGGER.error("valueRangeQueryOrderByDesc Error!", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }

--- a/opentsdb/src/main/java/cn/edu/tsinghua/iot/benchmark/opentsdb/OpenTSDB.java
+++ b/opentsdb/src/main/java/cn/edu/tsinghua/iot/benchmark/opentsdb/OpenTSDB.java
@@ -105,7 +105,7 @@ public class OpenTSDB implements IDatabase {
       HttpRequest.sendPost(writeUrl, sql);
       return new Status(true);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to insert one batch into OpenTSDB", e);
       return new Status(false, 0, e, e.toString());
     }
   }
@@ -263,7 +263,7 @@ public class OpenTSDB implements IDatabase {
       LOGGER.debug("{} 查到数据点数: {}", Thread.currentThread().getName(), pointNum);
       return new Status(true, pointNum);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to execute query against OpenTSDB", e);
       return new Status(false, 0, e, sql);
     }
   }

--- a/pi/src/main/java/cn/edu/tsinghua/iot/benchmark/piarchive/PIArchive.java
+++ b/pi/src/main/java/cn/edu/tsinghua/iot/benchmark/piarchive/PIArchive.java
@@ -79,7 +79,7 @@ public class PIArchive implements IDatabase {
           connection.prepareStatement("delete pipoint..classic where tag like 'g_%'");
       deletePointsStatement.execute();
     } catch (SQLException throwables) {
-      throwables.printStackTrace();
+      LOGGER.error("Failed to cleanup PI Archive data", throwables);
     }
   }
 
@@ -89,7 +89,7 @@ public class PIArchive implements IDatabase {
       try {
         connection.close();
       } catch (SQLException e) {
-        e.printStackTrace();
+        LOGGER.error("Failed to close PI Archive connection", e);
       }
     }
   }
@@ -120,7 +120,7 @@ public class PIArchive implements IDatabase {
         pStatement.clearBatch();
         pStatement.close();
       } catch (SQLException e) {
-        e.printStackTrace();
+        LOGGER.error("Failed to register PI Archive schema", e);
         throw new TsdbException(e);
       }
     }
@@ -326,7 +326,7 @@ public class PIArchive implements IDatabase {
           resultLineNum * config.getQUERY_SENSOR_NUM() * config.getQUERY_DEVICE_NUM();
       return new Status(true, queryResultPointNum);
     } catch (SQLException throwables) {
-      throwables.printStackTrace();
+      LOGGER.error("Failed to execute PI Archive query", throwables);
       return new Status(false, 0);
     }
   }

--- a/questdb/src/main/java/cn/edu/tsinghua/iot/benchmark/questdb/QuestDB.java
+++ b/questdb/src/main/java/cn/edu/tsinghua/iot/benchmark/questdb/QuestDB.java
@@ -90,8 +90,7 @@ public class QuestDB implements IDatabase {
               String.format(URL_QUEST, dbConfig.getHOST().get(0), dbConfig.getPORT().get(0)),
               properties);
     } catch (SQLException | ClassNotFoundException e) {
-      e.printStackTrace();
-      LOGGER.error("Failed to init database");
+      LOGGER.error("Failed to init database", e);
       throw new TsdbException("Failed to init database, maybe there is too much connections", e);
     }
   }
@@ -239,7 +238,7 @@ public class QuestDB implements IDatabase {
       statement.close();
       return new Status(true);
     } catch (SQLException e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to insert batch into QuestDB", e);
       System.out.println("Error!");
       return new Status(false, 0, e, e.toString());
     }
@@ -531,7 +530,7 @@ public class QuestDB implements IDatabase {
       queryResultPointNum = line * config.getQUERY_SENSOR_NUM() * config.getDEVICE_NUMBER();
       return new Status(true, queryResultPointNum);
     } catch (SQLException e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to execute QuestDB query", e);
       return new Status(false, 0, e, e.toString());
     }
   }

--- a/sqlite/src/main/java/cn/edu/tsinghua/iot/benchmark/sqlite/SqliteDB.java
+++ b/sqlite/src/main/java/cn/edu/tsinghua/iot/benchmark/sqlite/SqliteDB.java
@@ -231,8 +231,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("preciseQuery failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -259,8 +258,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("rangeQuery failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -288,8 +286,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("valueRangeQuery failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -321,8 +318,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("aggRangeQuery failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -348,8 +344,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("aggValueQuery failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -379,8 +374,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("aggRangeValueQuery failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -408,8 +402,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("groupByQuery failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -453,8 +446,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("latestPointQuery failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -482,8 +474,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("rangeQueryOrderByDesc failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }
@@ -512,8 +503,7 @@ public class SqliteDB implements IDatabase {
       statement.close();
       return new Status(true, result);
     } catch (SQLException sqlException) {
-      sqlException.printStackTrace();
-      LOGGER.error("preciseQuery Error!");
+      LOGGER.error("valueRangeQueryOrderByDesc failed", sqlException);
       return new Status(false, 0, sqlException, sqlException.getMessage());
     }
   }

--- a/tdengine-3.0/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine3/TDengine.java
+++ b/tdengine-3.0/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine3/TDengine.java
@@ -118,7 +118,7 @@ public class TDengine implements IDatabase {
                   dbConfig.getUSERNAME(),
                   dbConfig.getPASSWORD()));
     } catch (SQLException | ClassNotFoundException e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to initialize TDengine connection", e);
     }
   }
 

--- a/tdengine/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine/TDengine.java
+++ b/tdengine/src/main/java/cn/edu/tsinghua/iot/benchmark/tdengine/TDengine.java
@@ -102,7 +102,7 @@ public class TDengine implements IDatabase {
                   dbConfig.getPASSWORD()));
       LOGGER.info("TDengine init success.");
     } catch (SQLException | ClassNotFoundException e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to initialize TDengine connection", e);
     }
   }
 

--- a/victoriametrics/src/main/java/cn/edu/tsinghua/iot/benchmark/victoriametrics/HttpRequestUtil.java
+++ b/victoriametrics/src/main/java/cn/edu/tsinghua/iot/benchmark/victoriametrics/HttpRequestUtil.java
@@ -1,5 +1,8 @@
 package cn.edu.tsinghua.iot.benchmark.victoriametrics;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -8,6 +11,8 @@ import java.net.URL;
 import java.net.URLConnection;
 
 public class HttpRequestUtil {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequestUtil.class);
+
   /**
    * Send Get Request to target URL
    *
@@ -36,7 +41,7 @@ public class HttpRequestUtil {
         result.append(line);
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to send GET request to {}", url, e);
       throw e;
     } finally {
       try {
@@ -44,7 +49,7 @@ public class HttpRequestUtil {
           in.close();
         }
       } catch (Exception e2) {
-        e2.printStackTrace();
+        LOGGER.error("Failed to close connection after GET request", e2);
       }
     }
     return result.toString();

--- a/victoriametrics/src/main/java/cn/edu/tsinghua/iot/benchmark/victoriametrics/VictoriaMetrics.java
+++ b/victoriametrics/src/main/java/cn/edu/tsinghua/iot/benchmark/victoriametrics/VictoriaMetrics.java
@@ -133,7 +133,7 @@ public class VictoriaMetrics implements IDatabase {
           CREATE_URL, body.toString(), "text/plain; version=0.0.4; charset=utf-8");
       return new Status(true);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.error("Failed to insert one batch into VictoriaMetrics", e);
       return new Status(false, 0, e, e.toString());
     }
   }


### PR DESCRIPTION
## 问题
代码中大量使用 `e.printStackTrace()` 处理异常:堆栈只打到 stderr、不带任何上下文,也绕过了日志文件,排障时信息丢失。

## 改动
统一改为通过 SLF4J 记录:带可读的描述信息 + 异常对象。

- core:`Config`、`ConfigDescriptor`(仅此处的日志改动)、`CSVSchemaWriter`、`CSVDataReader`、`CopyDataReader`、`DBFactory`。
- 数据库适配器:InfluxDB2、IoTDB 1.3 / 2.0、KairosDB、MsSQLServer、OpenTSDB、PIArchive、QuestDB、SQLite、TDengine 2 / 3、VictoriaMetrics。

## 验证
`mvn -pl core test-compile spotless:check` 通过;抽取 SQLite、MsSQLServer 两个改动较大的适配器模块编译通过。

## 说明
基于 `master` 的独立分支。纯机械式日志替换,不改变控制流。
