### PR TITLE
fix(core): 修正 client-bind 模式下设备数校验逻辑(&& → ||)

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -641,14 +641,14 @@ public class ConfigDescriptor {
   }
 
   /** Check validation of config */
-  private boolean checkConfig() {
+  boolean checkConfig() {
     boolean result = true;
     // Checking config according to mode
     switch (config.getBENCHMARK_WORK_MODE()) {
       case TEST_WITH_DEFAULT_PATH:
         if (config.isIS_CLIENT_BIND()
-            && config.getDEVICE_NUMBER() < config.getSCHEMA_CLIENT_NUMBER()
-            && config.getDEVICE_NUMBER() < config.getDATA_CLIENT_NUMBER()) {
+            && (config.getDEVICE_NUMBER() < config.getSCHEMA_CLIENT_NUMBER()
+                || config.getDEVICE_NUMBER() < config.getDATA_CLIENT_NUMBER())) {
           LOGGER.error(
               "In client bind way, the number of schema client and data client should be less than the number of device");
           result = false;

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/BenchmarkTestBase.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/BenchmarkTestBase.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark;
+
+import cn.edu.tsinghua.iot.benchmark.conf.Constants;
+
+import java.io.File;
+
+/**
+ * Base class for every test that directly or transitively touches {@code ConfigDescriptor}.
+ *
+ * <p>{@code Config.initInnerFunction()} reads {@code function.xml} from the directory named by the
+ * {@code benchmark-conf} system property (default {@code configuration/conf}) and calls {@code
+ * System.exit(0)} when the file is missing. Under {@code mvn test -pl core} the surefire fork's
+ * working directory is the {@code core} module directory, where {@code configuration/conf} does not
+ * exist, so config-touching tests would silently abort.
+ *
+ * <p>This static initializer points the property at the repository's {@code configuration/conf}
+ * (resolved as {@code ../configuration/conf} from the core module dir). The JVM runs a superclass
+ * static initializer before any subclass static field initializer, so the property is set before a
+ * subclass's {@code static Config config = ConfigDescriptor.getInstance()...} runs. An externally
+ * supplied {@code -Dbenchmark-conf} is preserved.
+ */
+public abstract class BenchmarkTestBase {
+  static {
+    if (System.getProperty(Constants.BENCHMARK_CONF) == null) {
+      System.setProperty(
+          Constants.BENCHMARK_CONF, new File("../configuration/conf").getAbsolutePath());
+    }
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptorTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.conf;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.mode.enums.BenchmarkMode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigDescriptorTest extends BenchmarkTestBase {
+
+  private static final Config config = ConfigDescriptor.getInstance().getConfig();
+
+  private BenchmarkMode originalMode;
+  private boolean originalClientBind;
+  private int originalDeviceNumber;
+  private int originalSchemaClientNumber;
+  private int originalDataClientNumber;
+
+  @Before
+  public void before() {
+    originalMode = config.getBENCHMARK_WORK_MODE();
+    originalClientBind = config.isIS_CLIENT_BIND();
+    originalDeviceNumber = config.getDEVICE_NUMBER();
+    originalSchemaClientNumber = config.getSCHEMA_CLIENT_NUMBER();
+    originalDataClientNumber = config.getDATA_CLIENT_NUMBER();
+  }
+
+  @After
+  public void after() {
+    // restore the shared config singleton so this test does not pollute others
+    config.setBENCHMARK_WORK_MODE(originalMode);
+    config.setIS_CLIENT_BIND(originalClientBind);
+    config.setDEVICE_NUMBER(originalDeviceNumber);
+    config.setSCHEMA_CLIENT_NUMBER(originalSchemaClientNumber);
+    config.setDATA_CLIENT_NUMBER(originalDataClientNumber);
+  }
+
+  /**
+   * Regression test for issue #10: under {@code IS_CLIENT_BIND}, the validation joined the two
+   * "device number &lt; client number" checks with {@code &&}, so a config that has fewer devices
+   * than data clients (but not fewer than schema clients) was wrongly accepted. The fix uses {@code
+   * ||}.
+   *
+   * <p>The baseline assertion (enough devices -&gt; valid) guarantees the rest of {@code
+   * checkConfig()} passes for this config, so the {@code false} result below can only come from the
+   * client-bind rule.
+   */
+  @Test
+  public void testClientBindRejectsMoreClientsThanDevices() {
+    config.setBENCHMARK_WORK_MODE(BenchmarkMode.TEST_WITH_DEFAULT_PATH);
+    config.setIS_CLIENT_BIND(true);
+    config.setSCHEMA_CLIENT_NUMBER(1);
+    config.setDATA_CLIENT_NUMBER(100);
+
+    // baseline: device number >= every client number -> the rule must NOT trip
+    config.setDEVICE_NUMBER(200);
+    assertTrue(
+        "config should be valid when device number >= every client number",
+        ConfigDescriptor.getInstance().checkConfig());
+
+    // device number < data client number under client-bind must be rejected.
+    // Before the fix it was accepted because device (50) >= schema client (1).
+    config.setDEVICE_NUMBER(50);
+    assertFalse(
+        "client-bind with device number < data client number must be rejected",
+        ConfigDescriptor.getInstance().checkConfig());
+  }
+}


### PR DESCRIPTION
## 问题(逻辑缺陷)
`ConfigDescriptor.checkConfig()` 在 `TEST_WITH_DEFAULT_PATH` + client-bind 模式下,用 `&&` 连接 schema-client 与 data-client 两个比较:
```
isIS_CLIENT_BIND()
  && DEVICE_NUMBER < SCHEMA_CLIENT_NUMBER
  && DEVICE_NUMBER < DATA_CLIENT_NUMBER
```
只有当设备数同时少于**两者**时才报错;只对其中一类客户端数量不足的非法配置会被漏放过去。

## 改动
改为 `||`:任一类客户端数量超过设备数即判为非法。
```
isIS_CLIENT_BIND()
  && (DEVICE_NUMBER < SCHEMA_CLIENT_NUMBER
      || DEVICE_NUMBER < DATA_CLIENT_NUMBER)
```
同时将 `checkConfig()` 改为包级可见,便于单元测试。

## 验证
新增 `ConfigDescriptorTest`(经 `BenchmarkTestBase` 注入配置)通过;spotless 通过。

## 说明
基于 `master` 的独立分支。本分支与 logger 分支都改动了 `ConfigDescriptor.java`,但两处不重叠,合并时各取其一即可。`BenchmarkTestBase` 为共享测试基类,多个分支均包含,合并时若 add/add 冲突保留同一份即可。
