### PR TITLE
fix(core): 修复 AVG_LATENCY 虚高、吞吐除零与 CSV writer 资源关闭

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/measurement/Measurement.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/measurement/Measurement.java
@@ -46,8 +46,14 @@ public class Measurement {
   private static final Config config = ConfigDescriptor.getInstance().getConfig();
   private static final Map<Operation, TDigest> operationLatencyDigest =
       new EnumMap<>(Operation.class);
-  private static final Map<Operation, Double> operationLatencySumAllClient =
-      new EnumMap<>(Operation.class);
+
+  /**
+   * Aggregated latency sum across all clients. This is per-aggregator state (reset on every {@link
+   * #resetMeasurementMaps()}); it must NOT be static, otherwise repeated middle measurements keep
+   * accumulating into it and inflate AVG_LATENCY.
+   */
+  private final Map<Operation, Double> operationLatencySumAllClient;
+
   private double createSchemaFinishTime = 0;
   private double elapseTime;
   private final Map<Operation, Double> operationLatencySumThisClient;
@@ -65,7 +71,6 @@ public class Measurement {
     for (Operation operation : Operation.values()) {
       operationLatencyDigest.put(
           operation, new TDigest(COMPRESSION, new Random(config.getDATA_SEED())));
-      operationLatencySumAllClient.put(operation, 0D);
     }
   }
 
@@ -75,6 +80,7 @@ public class Measurement {
     okPointNumMap = new EnumMap<>(Operation.class);
     failPointNumMap = new EnumMap<>(Operation.class);
     operationLatencySumThisClient = new EnumMap<>(Operation.class);
+    operationLatencySumAllClient = new EnumMap<>(Operation.class);
     resetMeasurementMaps();
   }
 
@@ -85,6 +91,7 @@ public class Measurement {
       okPointNumMap.put(operation, 0L);
       failPointNumMap.put(operation, 0L);
       operationLatencySumThisClient.put(operation, 0D);
+      operationLatencySumAllClient.put(operation, 0D);
     }
   }
 
@@ -220,7 +227,8 @@ public class Measurement {
             "failPoint",
             "throughput(point/s)"));
     for (Operation operation : operations) {
-      String throughput = String.format("%.2f", okPointNumMap.get(operation) / elapseTime);
+      double throughputValue = elapseTime > 0 ? okPointNumMap.get(operation) / elapseTime : 0.0;
+      String throughput = String.format("%.2f", throughputValue);
       stringBuilder.append(
           String.format(
               format.toString(),
@@ -371,11 +379,9 @@ public class Measurement {
 
     /** Write config to csv */
     private void outputConfigToCSV(File csv) {
-      try {
-        BufferedWriter bw = new BufferedWriter(new FileWriter(csv, true));
+      try (BufferedWriter bw = new BufferedWriter(new FileWriter(csv, true))) {
         bw.write("Main Configurations" + System.lineSeparator());
         bw.write(config.getAllConfigProperties().toString());
-        bw.close();
       } catch (IOException e) {
         LOGGER.error("Exception occurred during operating buffer writer because: ", e);
       }
@@ -383,8 +389,7 @@ public class Measurement {
 
     /** Write result metric to csv */
     private void outputResultMetricToCSV(File csv) {
-      try {
-        BufferedWriter bw = new BufferedWriter(new FileWriter(csv, true));
+      try (BufferedWriter bw = new BufferedWriter(new FileWriter(csv, true))) {
         bw.newLine();
         bw.write("Result Matrix");
         bw.newLine();
@@ -401,7 +406,8 @@ public class Measurement {
                 + ","
                 + "throughput(point/s)");
         for (Operation operation : Operation.values()) {
-          String throughput = String.format("%.2f", okPointNumMap.get(operation) / elapseTime);
+          double throughputValue = elapseTime > 0 ? okPointNumMap.get(operation) / elapseTime : 0.0;
+          String throughput = String.format("%.2f", throughputValue);
           bw.newLine();
           bw.write(
               operation.getName()
@@ -416,7 +422,6 @@ public class Measurement {
                   + ","
                   + throughput);
         }
-        bw.close();
       } catch (IOException e) {
         LOGGER.error("Exception occurred during operating buffer writer because: ", e);
       }
@@ -424,8 +429,7 @@ public class Measurement {
 
     /** Write Latency metric to csv */
     private void outputLatencyMetricsToCSV(File csv) {
-      try {
-        BufferedWriter bw = new BufferedWriter(new FileWriter(csv, true));
+      try (BufferedWriter bw = new BufferedWriter(new FileWriter(csv, true))) {
         bw.newLine();
         bw.write("Latency (ms) Matrix");
         bw.newLine();
@@ -442,7 +446,6 @@ public class Measurement {
           }
           bw.newLine();
         }
-        bw.close();
       } catch (IOException e) {
         LOGGER.error("Exception occurred during operating buffer writer because: ", e);
       }
@@ -450,15 +453,13 @@ public class Measurement {
   }
 
   private void outputSchemaMetricsToCSV(File csv) {
-    try {
-      BufferedWriter bw = new BufferedWriter(new FileWriter(csv, true));
+    try (BufferedWriter bw = new BufferedWriter(new FileWriter(csv, true))) {
       bw.newLine();
       bw.write(String.format("Schema cost(s),%.2f", createSchemaFinishTime));
       bw.newLine();
       bw.write(
           String.format("Test elapsed time (not include schema creation)(s),%.2f", elapseTime));
       bw.newLine();
-      bw.close();
     } catch (IOException e) {
       LOGGER.error("Exception occurred during operating buffer writer because: ", e);
     }

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/BenchmarkTestBase.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/BenchmarkTestBase.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark;
+
+import cn.edu.tsinghua.iot.benchmark.conf.Constants;
+
+import java.io.File;
+
+/**
+ * Base class for every test that directly or transitively touches {@code ConfigDescriptor}.
+ *
+ * <p>{@code Config.initInnerFunction()} reads {@code function.xml} from the directory named by the
+ * {@code benchmark-conf} system property (default {@code configuration/conf}) and calls {@code
+ * System.exit(0)} when the file is missing. Under {@code mvn test -pl core} the surefire fork's
+ * working directory is the {@code core} module directory, where {@code configuration/conf} does not
+ * exist, so config-touching tests would silently abort.
+ *
+ * <p>This static initializer points the property at the repository's {@code configuration/conf}
+ * (resolved as {@code ../configuration/conf} from the core module dir). The JVM runs a superclass
+ * static initializer before any subclass static field initializer, so the property is set before a
+ * subclass's {@code static Config config = ConfigDescriptor.getInstance()...} runs. An externally
+ * supplied {@code -Dbenchmark-conf} is preserved.
+ */
+public abstract class BenchmarkTestBase {
+  static {
+    if (System.getProperty(Constants.BENCHMARK_CONF) == null) {
+      System.setProperty(
+          Constants.BENCHMARK_CONF, new File("../configuration/conf").getAbsolutePath());
+    }
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/measurement/MeasurementTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/measurement/MeasurementTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.measurement;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.client.operation.Operation;
+import cn.edu.tsinghua.iot.benchmark.measurement.enums.Metric;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class MeasurementTest extends BenchmarkTestBase {
+
+  private static final double DELTA = 1e-9;
+
+  /**
+   * Regression test for the AVG_LATENCY accumulation bug (issue #1).
+   *
+   * <p>{@code BaseMode.measure()} performs {@code resetMeasurementMaps() + mergeMeasurement() +
+   * calculateMetrics()} on every periodic (middle) measurement. With the same underlying client
+   * data, two consecutive measurements must yield the same AVG_LATENCY. Previously {@code
+   * operationLatencySumAllClient} was static and never reset, so the second measurement doubled the
+   * numerator while the denominator stayed correct, inflating AVG_LATENCY.
+   */
+  @Test
+  public void testAvgLatencyNotAccumulatedAcrossMeasurements() {
+    Operation op = Operation.PRECISE_QUERY;
+    List<Operation> operations = Collections.singletonList(op);
+
+    // one client with two operations: latencies 10ms and 20ms -> sum 30, count 2, avg 15
+    Measurement client = new Measurement();
+    client.addOperationLatency(op, 10.0);
+    client.addOkOperationNum(op);
+    client.addOperationLatency(op, 20.0);
+    client.addOkOperationNum(op);
+
+    Measurement aggregator = new Measurement();
+
+    double avgFirst = measureAndGetAvg(aggregator, client, operations, op);
+    double avgSecond = measureAndGetAvg(aggregator, client, operations, op);
+
+    assertEquals(
+        "AVG_LATENCY must not change when client data is unchanged", avgFirst, avgSecond, DELTA);
+    assertEquals(15.0, avgSecond, DELTA);
+  }
+
+  /** Mirrors the reset + merge + calculate flow that {@code BaseMode.measure()} runs each time. */
+  private double measureAndGetAvg(
+      Measurement aggregator, Measurement client, List<Operation> operations, Operation op) {
+    aggregator.resetMeasurementMaps();
+    aggregator.mergeMeasurement(client);
+    aggregator.calculateMetrics(operations);
+    return Metric.AVG_LATENCY.getTypeValueMap().get(op);
+  }
+}


### PR DESCRIPTION
## 背景

`Measurement` 在运行期被 `BaseMode` 反复调用做统计：`setMiddleMeasureScheduler()` 每隔 `RESULT_PRINT_INTERVAL` 秒触发一次中间统计，测试结束再做一次最终统计，二者复用同一个聚合器实例，每轮流程都是 `resetMeasurementMaps()` → 各 client `mergeMeasurement()` → `calculateMetrics()`。

本 PR 主要修 `AVG_LATENCY` 计算错误，顺带处理同文件里两个稳健性问题。

## 1. AVG_LATENCY 虚高

`AVG_LATENCY = operationLatencySumAllClient / okOperationNumMap`。分母 `okOperationNumMap` 在每轮 `resetMeasurementMaps()` 里清零、再由 merge 重算，反映当前快照；而分子 `operationLatencySumAllClient` 被声明成 `static`，只在类加载的 static 块里清过一次，`resetMeasurementMaps()` 并没有把它清零，`mergeMeasurement` 每轮却又往里做加法。

于是分子跨轮累加、分母每轮重置，节奏不一致：设第 N 轮各 client 的累计延迟和为 Sₙ、成功数为 Cₙ，正确值应恒为 Sₙ/Cₙ，实际却变成 (S₁+…+Sₙ)/Cₙ，平均时延随运行时间不断放大。

修复方式是把 `operationLatencySumAllClient` 改为实例字段，并纳入 `resetMeasurementMaps()`。两者缺一不可：纳入 reset 才能消除跨轮累加（聚合器是同一实例复用），改为实例字段则避免 static 在多实例 / 单测之间共享状态。

需要说明的是 `operationLatencySumThisClient` 与 `operationLatencyDigest` 同样是逐 client 数据：前者本就是实例字段、已在 reset 中清零；后者虽是 static 且不参与 reset，但它由 client 直接 `add`、merge 从不经手，本就应持有全程样本来算分位数，因此保持不变。真正错的只有「被 merge 累加却漏掉 reset」的这一个 map。

### 触发条件

默认 `RESULT_PRINT_INTERVAL = 3600`，若单次运行不足一小时，中间统计不会触发，只有最终统计跑一次 merge，结果正确——这也是问题此前未被发现的原因。一旦调小打印间隔观察进度，或运行时长超过该间隔，中间统计触发后不仅进度输出偏大，最终结果同样偏大（最终统计会在已累加的值上再加一轮）。

## 2. 吞吐除零

`okPointNum / elapseTime` 在 `elapseTime == 0` 时得到 `NaN / Infinity`。增加 `elapseTime > 0` 守卫，否则取 0。

## 3. CSV writer 资源未关闭

4 处写 CSV 的 `BufferedWriter` 未用 try-with-resources，写入异常时不会关闭。改为 try-with-resources。

## 验证

新增 `MeasurementTest`（基于 `BenchmarkTestBase`）：用同一份 client 数据连续做两轮中间统计，断言 `AVG_LATENCY` 不随轮次变化。修复前第二轮会翻倍，修复后保持一致。spotless 通过。

## 备注

基于 `master` 的独立分支。与 dbwrapper 分支都改动了 `Measurement.java`，但两处不重叠（本分支不含 getter 可见性改动），合并时各取其一即可。
