### PR TITLE
fix(core): DBWrapper 快速失败并容错退化查询结果

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/measurement/Measurement.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/measurement/Measurement.java
@@ -468,19 +468,19 @@ public class Measurement {
     return operationLatencySumThisClient;
   }
 
-  private long getOkOperationNum(Operation operation) {
+  public long getOkOperationNum(Operation operation) {
     return okOperationNumMap.get(operation);
   }
 
-  private long getFailOperationNum(Operation operation) {
+  public long getFailOperationNum(Operation operation) {
     return failOperationNumMap.get(operation);
   }
 
-  private long getOkPointNum(Operation operation) {
+  public long getOkPointNum(Operation operation) {
     return okPointNumMap.get(operation);
   }
 
-  private long getFailPointNum(Operation operation) {
+  public long getFailPointNum(Operation operation) {
     return failPointNumMap.get(operation);
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/DBWrapper.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/DBWrapper.java
@@ -69,17 +69,27 @@ public class DBWrapper implements IDatabase {
     DBFactory dbFactory = new DBFactory();
     for (DBConfig dbConfig : dbConfigs) {
       try {
-        IDatabase database = dbFactory.getDatabase(dbConfig);
-        if (database == null) {
-          LOGGER.error("Failed to get database: " + dbConfig);
-        }
-        databases.add(database);
+        // getDatabase never returns null: it returns an instance or throws.
+        databases.add(dbFactory.getDatabase(dbConfig));
       } catch (Exception e) {
-        LOGGER.error("Failed to get database because", e);
+        // Fail fast. Swallowing this leaves databases empty so every later operation no-ops and
+        // the benchmark "succeeds" while reading/writing nothing.
+        throw new IllegalStateException("Failed to initialize database for config:" + dbConfig, e);
       }
     }
     PersistenceFactory persistenceFactory = new PersistenceFactory();
     recorder = persistenceFactory.getPersistence();
+  }
+
+  /**
+   * Test seam: build a wrapper around already-instantiated databases, bypassing {@link DBFactory}.
+   * Lets unit tests inject fake {@link IDatabase} doubles with controllable return values, which
+   * the public {@code List<DBConfig>} constructor (reflection via DBFactory) cannot do.
+   */
+  static DBWrapper forTest(List<IDatabase> databases) {
+    DBWrapper dbWrapper = new DBWrapper(new ArrayList<DBConfig>());
+    dbWrapper.databases = databases;
+    return dbWrapper;
   }
 
   public Measurement getMeasurement() {
@@ -286,9 +296,9 @@ public class DBWrapper implements IDatabase {
         status = database.aggRangeValueQuery(aggRangeValueQuery);
         long end = System.nanoTime();
         status.setTimeCost(end - start);
+        handleQueryOperation(status, operation, device);
         statuses.add(status);
       }
-      handleQueryOperation(status, operation, device);
       doComparisonByRecord(aggRangeValueQuery, operation, statuses);
     } catch (Exception e) {
       handleUnexpectedQueryException(operation, e, device);
@@ -504,28 +514,33 @@ public class DBWrapper implements IDatabase {
     try {
       List<DeviceSummary> deviceSummaries = new ArrayList<>();
       for (IDatabase database : databases) {
-        deviceSummary = database.deviceSummary(deviceQuery);
-        if (deviceSummary == null) {
+        DeviceSummary summary = database.deviceSummary(deviceQuery);
+        if (summary == null) {
           LOGGER.error("Failed to get summary: {}", database.getClass().getName());
           continue;
         }
-        deviceSummaries.add(deviceSummary);
+        deviceSummaries.add(summary);
       }
-      DeviceSummary base = deviceSummaries.get(0);
+      if (deviceSummaries.isEmpty()) {
+        LOGGER.error("No device summary obtained from any database.");
+        return null;
+      }
+      // deviceSummary now holds the agreed-upon summary (non-null), so the final log and return
+      // below are safe; previously the last loop iteration could leave it null and NPE.
+      deviceSummary = deviceSummaries.get(0);
       for (int i = 1; i < deviceSummaries.size(); i++) {
-        if (!base.equals(deviceSummaries.get(i))) {
+        if (!deviceSummary.equals(deviceSummaries.get(i))) {
           LOGGER.error("Error number of different database: ");
-          LOGGER.error("DB1:" + base);
+          LOGGER.error("DB1:" + deviceSummary);
           LOGGER.error("DB2:" + deviceSummaries.get(i));
           return null;
         }
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to get summary of device");
-      e.printStackTrace();
+      LOGGER.error("Failed to get summary of device", e);
       return null;
     }
-    LOGGER.info("Device Summary:" + deviceSummary.toString());
+    LOGGER.info("Device Summary:" + deviceSummary);
     return deviceSummary;
   }
 
@@ -605,6 +620,13 @@ public class DBWrapper implements IDatabase {
   private int doPointComparison(List<Status> statuses, DeviceQuery deviceQuery) {
     int totalPointNumber = 0;
 
+    if (statuses.size() < 2) {
+      // Point comparison needs two databases (double write); with one it must skip, not crash.
+      LOGGER.error(
+          "Point comparison requires at least two databases but got {}; skipping comparison.",
+          statuses.size());
+      return -1;
+    }
     long start = System.nanoTime();
     Status status1 = statuses.get(0);
     Status status2 = statuses.get(1);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/fakedb/FakeDB.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/fakedb/FakeDB.java
@@ -22,6 +22,7 @@ package cn.edu.tsinghua.iot.benchmark.tsdb.fakedb;
 import cn.edu.tsinghua.iot.benchmark.entity.Batch.IBatch;
 import cn.edu.tsinghua.iot.benchmark.measurement.Status;
 import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
+import cn.edu.tsinghua.iot.benchmark.tsdb.DBConfig;
 import cn.edu.tsinghua.iot.benchmark.tsdb.IDatabase;
 import cn.edu.tsinghua.iot.benchmark.tsdb.TsdbException;
 import cn.edu.tsinghua.iot.benchmark.workload.query.impl.AggRangeQuery;
@@ -36,6 +37,15 @@ import cn.edu.tsinghua.iot.benchmark.workload.query.impl.ValueRangeQuery;
 import java.util.List;
 
 public class FakeDB implements IDatabase {
+
+  public FakeDB() {}
+
+  /**
+   * {@link cn.edu.tsinghua.iot.benchmark.tsdb.DBFactory#getDatabase} instantiates every adapter via
+   * its {@code (DBConfig)} constructor; without this one FakeDB cannot be loaded by {@code
+   * DB_SWITCH=FakeDB}. The config is unused because FakeDB talks to no real database.
+   */
+  public FakeDB(DBConfig dbConfig) {}
 
   @Override
   public void init() throws TsdbException {}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/BenchmarkTestBase.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/BenchmarkTestBase.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark;
+
+import cn.edu.tsinghua.iot.benchmark.conf.Constants;
+
+import java.io.File;
+
+/**
+ * Base class for every test that directly or transitively touches {@code ConfigDescriptor}.
+ *
+ * <p>{@code Config.initInnerFunction()} reads {@code function.xml} from the directory named by the
+ * {@code benchmark-conf} system property (default {@code configuration/conf}) and calls {@code
+ * System.exit(0)} when the file is missing. Under {@code mvn test -pl core} the surefire fork's
+ * working directory is the {@code core} module directory, where {@code configuration/conf} does not
+ * exist, so config-touching tests would silently abort.
+ *
+ * <p>This static initializer points the property at the repository's {@code configuration/conf}
+ * (resolved as {@code ../configuration/conf} from the core module dir). The JVM runs a superclass
+ * static initializer before any subclass static field initializer, so the property is set before a
+ * subclass's {@code static Config config = ConfigDescriptor.getInstance()...} runs. An externally
+ * supplied {@code -Dbenchmark-conf} is preserved.
+ */
+public abstract class BenchmarkTestBase {
+  static {
+    if (System.getProperty(Constants.BENCHMARK_CONF) == null) {
+      System.setProperty(
+          Constants.BENCHMARK_CONF, new File("../configuration/conf").getAbsolutePath());
+    }
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/mode/FakeDBEndToEndTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/mode/FakeDBEndToEndTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.mode;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.client.operation.Operation;
+import cn.edu.tsinghua.iot.benchmark.conf.Config;
+import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
+import cn.edu.tsinghua.iot.benchmark.conf.Constants;
+import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
+import cn.edu.tsinghua.iot.benchmark.mode.enums.BenchmarkMode;
+import cn.edu.tsinghua.iot.benchmark.tsdb.enums.DBSwitch;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * End-to-end smoke test of the whole {@link BaseMode} pipeline (register schema → write → read →
+ * aggregate) driven against {@link cn.edu.tsinghua.iot.benchmark.tsdb.fakedb.FakeDB}, so no real
+ * database is required.
+ *
+ * <p>This is the regression net for the "ran to completion but actually wrote/read nothing" class
+ * of bugs (#1, #8): FakeDB returns success for every operation, so a healthy run must end with
+ * non-zero ok operation/point counts and zero failures. An empty database list, a swallowed init
+ * failure, or a measurement that never accumulates would all show up here as zero counts.
+ *
+ * <p>FakeDB itself only became loadable through {@code DBFactory} once it gained a {@code
+ * (DBConfig)} constructor, so this test also exercises that wiring.
+ */
+public class FakeDBEndToEndTest extends BenchmarkTestBase {
+
+  private static final Config config = ConfigDescriptor.getInstance().getConfig();
+
+  /**
+   * DEVICE_NUMBER == default SENSOR_NUMBER keeps the workload singletons consistent across tests.
+   */
+  private static final int DEVICES = 200;
+
+  private DBSwitch origDbSwitch;
+  private String origPersistence;
+  private boolean origUseMeasurement;
+  private int origDeviceNumber;
+  private int origDataClientNumber;
+  private int origSchemaClientNumber;
+  private long origLoop;
+  private int origBatchSize;
+  private boolean origCreateSchema;
+  private boolean origDeleteData;
+  private boolean origClientBind;
+  private String origOperationProportion;
+  private int origResultPrintInterval;
+  private Long origTestMaxTime;
+
+  @Before
+  public void setUp() {
+    origDbSwitch = config.getDbConfig().getDB_SWITCH();
+    origPersistence = config.getTEST_DATA_PERSISTENCE();
+    origUseMeasurement = config.isUSE_MEASUREMENT();
+    origDeviceNumber = config.getDEVICE_NUMBER();
+    origDataClientNumber = config.getDATA_CLIENT_NUMBER();
+    origSchemaClientNumber = config.getSCHEMA_CLIENT_NUMBER();
+    origLoop = config.getLOOP();
+    origBatchSize = config.getBATCH_SIZE_PER_WRITE();
+    origCreateSchema = config.isCREATE_SCHEMA();
+    origDeleteData = config.isIS_DELETE_DATA();
+    origClientBind = config.isIS_CLIENT_BIND();
+    origOperationProportion = config.getOPERATION_PROPORTION();
+    origResultPrintInterval = config.getRESULT_PRINT_INTERVAL();
+    origTestMaxTime = config.getTEST_MAX_TIME();
+
+    // Talk to FakeDB only — no real database, every operation returns success.
+    config.getDbConfig().setDB_SWITCH(DBSwitch.DB_FAKE);
+    // Do not write CSV/MySQL/IoTDB persistence files during the test.
+    config.setTEST_DATA_PERSISTENCE(Constants.TDP_NONE);
+    config.setUSE_MEASUREMENT(true);
+    config.setBENCHMARK_WORK_MODE(BenchmarkMode.TEST_WITH_DEFAULT_PATH);
+    config.setDEVICE_NUMBER(DEVICES);
+    config.setDATA_CLIENT_NUMBER(1);
+    config.setSCHEMA_CLIENT_NUMBER(1);
+    config.setLOOP(100);
+    config.setBATCH_SIZE_PER_WRITE(10);
+    config.setCREATE_SCHEMA(true);
+    // FakeDB has no data to delete; skip cleanup to keep the run minimal.
+    config.setIS_DELETE_DATA(false);
+    config.setIS_CLIENT_BIND(true);
+    // write : preciseQuery : rangeQuery : (rest 0) — exercises both the write and read paths.
+    config.setOPERATION_PROPORTION("1:1:1:0:0:0:0:0:0:0:0:0:0");
+    // Disable the periodic background schedulers so run() stays self-contained and fast.
+    config.setRESULT_PRINT_INTERVAL(0);
+    config.setTEST_MAX_TIME(0L);
+  }
+
+  @After
+  public void tearDown() {
+    config.getDbConfig().setDB_SWITCH(origDbSwitch);
+    config.setTEST_DATA_PERSISTENCE(origPersistence);
+    config.setUSE_MEASUREMENT(origUseMeasurement);
+    config.setDEVICE_NUMBER(origDeviceNumber);
+    config.setDATA_CLIENT_NUMBER(origDataClientNumber);
+    config.setSCHEMA_CLIENT_NUMBER(origSchemaClientNumber);
+    config.setLOOP(origLoop);
+    config.setBATCH_SIZE_PER_WRITE(origBatchSize);
+    config.setCREATE_SCHEMA(origCreateSchema);
+    config.setIS_DELETE_DATA(origDeleteData);
+    config.setIS_CLIENT_BIND(origClientBind);
+    config.setOPERATION_PROPORTION(origOperationProportion);
+    config.setRESULT_PRINT_INTERVAL(origResultPrintInterval);
+    config.setTEST_MAX_TIME(origTestMaxTime);
+  }
+
+  @Test
+  public void fullRunAgainstFakeDbWritesAndReadsSomething() {
+    TestWithDefaultPathMode mode = new TestWithDefaultPathMode();
+    mode.run();
+
+    Measurement measurement = mode.baseModeMeasurement;
+
+    long ingestionOps = measurement.getOkOperationNum(Operation.INGESTION);
+    long ingestionPoints = measurement.getOkPointNum(Operation.INGESTION);
+    assertTrue(
+        "the benchmark completed but recorded no successful writes — it ran against nothing",
+        ingestionOps > 0);
+    assertTrue("successful writes recorded no data points", ingestionPoints > 0);
+
+    long readOps =
+        measurement.getOkOperationNum(Operation.PRECISE_QUERY)
+            + measurement.getOkOperationNum(Operation.RANGE_QUERY);
+    assertTrue("the benchmark recorded no successful reads", readOps > 0);
+
+    long totalFailures = 0;
+    for (Operation operation : Operation.getNormalOperation()) {
+      totalFailures += measurement.getFailOperationNum(operation);
+    }
+    assertEquals(
+        "FakeDB returns success for every operation; nothing should fail", 0L, totalFailures);
+
+    assertTrue("elapsed time was not recorded", measurement.getElapseTime() > 0);
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/tsdb/DBWrapperTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/tsdb/DBWrapperTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.tsdb;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.client.operation.Operation;
+import cn.edu.tsinghua.iot.benchmark.conf.Config;
+import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
+import cn.edu.tsinghua.iot.benchmark.entity.DeviceSummary;
+import cn.edu.tsinghua.iot.benchmark.measurement.Measurement;
+import cn.edu.tsinghua.iot.benchmark.measurement.Status;
+import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
+import cn.edu.tsinghua.iot.benchmark.tsdb.fakedb.FakeDB;
+import cn.edu.tsinghua.iot.benchmark.workload.query.impl.AggRangeQuery;
+import cn.edu.tsinghua.iot.benchmark.workload.query.impl.AggRangeValueQuery;
+import cn.edu.tsinghua.iot.benchmark.workload.query.impl.DeviceQuery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression tests for the {@link DBWrapper} correctness defects #8/#9/#11/#12 from the core
+ * review.
+ *
+ * <p>{@code DBWrapper.databases} is private and only populated through {@link DBFactory}
+ * reflection, so these tests inject {@link FakeDB}-based doubles via the {@link DBWrapper#forTest}
+ * seam and read the per-operation counters back from {@link DBWrapper#getMeasurement()}.
+ */
+public class DBWrapperTest extends BenchmarkTestBase {
+
+  private static final Config config = ConfigDescriptor.getInstance().getConfig();
+
+  private boolean originalUseMeasurement;
+
+  @Before
+  public void enableMeasurement() {
+    // The wrapper only records operation counters when measurement is enabled.
+    originalUseMeasurement = config.isUSE_MEASUREMENT();
+    config.setUSE_MEASUREMENT(true);
+  }
+
+  @After
+  public void restoreConfig() {
+    config.setUSE_MEASUREMENT(originalUseMeasurement);
+  }
+
+  /**
+   * #8 — A database that cannot be initialized must abort the run, not leave {@code databases}
+   * empty so the benchmark "succeeds" while writing nothing.
+   *
+   * <p>The default {@link DBConfig} points at an IoTDB switch whose adapter class lives in a
+   * separate module and is absent from the core test classpath, so {@link DBFactory#getDatabase}
+   * fails for it.
+   */
+  @Test
+  public void constructionFailureMustNotBeSilent() {
+    List<DBConfig> configs = Collections.singletonList(new DBConfig());
+    try {
+      new DBWrapper(configs);
+      fail(
+          "DBWrapper must fail fast when a database cannot be initialized; otherwise it runs "
+              + "against an empty database list and silently writes nothing");
+    } catch (IllegalStateException expected) {
+      // expected once #8 is fixed
+    }
+  }
+
+  /**
+   * #9 — {@code aggRangeValueQuery} measured the query outside the per-database loop, counting only
+   * the last database. Every other query method counts once per database; this asserts the parity.
+   */
+  @Test
+  public void aggRangeValueQueryCountsEveryDatabaseLikeItsSiblings() {
+    List<IDatabase> twoDatabases = Arrays.<IDatabase>asList(new FakeDB(), new FakeDB());
+    DBWrapper wrapper = DBWrapper.forTest(twoDatabases);
+
+    wrapper.aggRangeQuery(new AggRangeQuery(new ArrayList<>(), 0L, 1L, "avg"));
+    wrapper.aggRangeValueQuery(new AggRangeValueQuery(new ArrayList<>(), 0L, 1L, "avg", 0.0));
+
+    Measurement measurement = wrapper.getMeasurement();
+    assertEquals(
+        "sanity: the correct sibling counts once per database",
+        2L,
+        measurement.getOkOperationNum(Operation.AGG_RANGE_QUERY));
+    assertEquals(
+        "aggRangeValueQuery must count once per database, like every other query method",
+        measurement.getOkOperationNum(Operation.AGG_RANGE_QUERY),
+        measurement.getOkOperationNum(Operation.AGG_RANGE_VALUE_QUERY));
+  }
+
+  /**
+   * #11 — When the last database returns a null summary, the original code dereferenced the stale
+   * {@code deviceSummary} reference outside the try/catch and threw {@link NullPointerException}.
+   * The agreed-upon summary from the databases that did answer must be returned instead.
+   */
+  @Test
+  public void deviceSummaryMustNotThrowWhenSomeDatabasesReturnNull() throws Exception {
+    DeviceSummary summary = new DeviceSummary("d_0", 10, 0L, 100L);
+    List<IDatabase> databases =
+        Arrays.<IDatabase>asList(new FixedSummaryDB(summary), new FixedSummaryDB(null));
+    DBWrapper wrapper = DBWrapper.forTest(databases);
+
+    assertEquals(summary, wrapper.deviceSummary(new DeviceQuery()));
+  }
+
+  /** #11 — With no usable summary at all, the wrapper must return null gracefully, not crash. */
+  @Test
+  public void deviceSummaryReturnsNullWhenAllDatabasesReturnNull() throws Exception {
+    List<IDatabase> databases =
+        Arrays.<IDatabase>asList(new FixedSummaryDB(null), new FixedSummaryDB(null));
+    DBWrapper wrapper = DBWrapper.forTest(databases);
+
+    assertNull(wrapper.deviceSummary(new DeviceQuery()));
+  }
+
+  /**
+   * #12 — {@code doPointComparison} indexed {@code statuses.get(1)} with no size guard, so a single
+   * configured database made every device query throw and be recorded as a failure. With one
+   * database the comparison must be skipped and the query counted as a success.
+   */
+  @Test
+  public void deviceQueryWithSingleDatabaseIsNotCountedAsFailure() throws Exception {
+    List<IDatabase> singleDatabase = Collections.<IDatabase>singletonList(new RecordReturningDB());
+    DBWrapper wrapper = DBWrapper.forTest(singleDatabase);
+
+    DeviceSchema deviceSchema = new DeviceSchema();
+    deviceSchema.setDevice("d_0");
+    wrapper.deviceQuery(new DeviceQuery(deviceSchema));
+
+    Measurement measurement = wrapper.getMeasurement();
+    assertEquals(
+        "single-database device query must not be recorded as a failure",
+        0L,
+        measurement.getFailOperationNum(Operation.DEVICE_QUERY));
+    assertEquals(1L, measurement.getOkOperationNum(Operation.DEVICE_QUERY));
+  }
+
+  /** Returns a preset (possibly null) device summary, ignoring the query. */
+  private static class FixedSummaryDB extends FakeDB {
+    private final DeviceSummary summary;
+
+    FixedSummaryDB(DeviceSummary summary) {
+      this.summary = summary;
+    }
+
+    @Override
+    public DeviceSummary deviceSummary(DeviceQuery deviceQuery) {
+      return summary;
+    }
+  }
+
+  /** Returns a successful device query with a single record row. */
+  private static class RecordReturningDB extends FakeDB {
+    @Override
+    public Status deviceQuery(DeviceQuery deviceQuery) {
+      List<List<Object>> records = new ArrayList<>();
+      List<Object> row = new ArrayList<>();
+      row.add(0L);
+      row.add(1);
+      records.add(row);
+      return new Status(true, 1, "fake-sql", records);
+    }
+  }
+}


### PR DESCRIPTION
## 问题
`DBWrapper` 在若干退化场景下行为不健壮:
1. 初始化吞掉 `DBFactory` 异常,使 `databases` 为空,之后所有操作静默 no-op,基准测试却"成功",实际什么都没读写。
2. `deviceSummary()` 在最后一次循环可能让结果引用保持 null,随后 NPE。
3. `aggRangeValueQuery` 的 `handleQueryOperation` 位置不当。
4. `doPointComparison()` 在数据库少于两个(非双写)时按下标取值越界。

## 改动
1. 初始化失败直接抛 `IllegalStateException`,**快速失败**。
2. `deviceSummary()`:结果为空时返回 null;复用已确认的非空 summary,消除 NPE。
3. `aggRangeValueQuery`:在循环内逐条记录 status。
4. `doPointComparison()`:少于两个数据库时跳过(返回 -1),不再越界。
5. 增加测试缝:`DBWrapper.forTest`、`FakeDB(DBConfig)` 构造器、`Measurement` 计数器 getter 改 public,便于注入 fake 并断言计数。

## 验证
新增 `DBWrapperTest`、`FakeDBEndToEndTest`(经 `BenchmarkTestBase`)共 6 个用例通过;spotless 通过。

## 说明
基于 `master` 的独立分支。`Measurement.java` 仅含 getter 可见性改动,与 measurement 分支不重叠。
