### PR TITLE
fix(core): BytesUtils.twoBytesToInt 屏蔽符号位

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/utils/BytesUtils.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/utils/BytesUtils.java
@@ -129,9 +129,9 @@ public class BytesUtils {
       throw new IllegalArgumentException("Invalid input: ret.length != 2");
     }
     int value = 0;
-    value |= ret[0];
+    value |= ret[0] & 0xFF;
     value = value << 8;
-    value |= ret[1];
+    value |= ret[1] & 0xFF;
     return value;
   }
 

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/BytesUtilsTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/BytesUtilsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class BytesUtilsTest {
+
+  @Test
+  public void testIntRoundTrip() {
+    for (int v : new int[] {0, 1, -1, 42, Integer.MAX_VALUE, Integer.MIN_VALUE}) {
+      assertEquals(v, BytesUtils.bytesToInt(BytesUtils.intToBytes(v)));
+    }
+  }
+
+  @Test
+  public void testLongRoundTrip() {
+    for (long v : new long[] {0L, 1L, -1L, 123456789L, Long.MAX_VALUE, Long.MIN_VALUE}) {
+      assertEquals(v, BytesUtils.bytesToLong(BytesUtils.longToBytes(v)));
+    }
+  }
+
+  @Test
+  public void testFloatRoundTrip() {
+    for (float v : new float[] {0f, 1.5f, -2.5f, Float.MAX_VALUE, Float.MIN_VALUE}) {
+      assertEquals(v, BytesUtils.bytesToFloat(BytesUtils.floatToBytes(v)), 0.0f);
+    }
+  }
+
+  @Test
+  public void testDoubleRoundTrip() {
+    for (double v : new double[] {0d, 3.14159d, -2.71828d, Double.MAX_VALUE, Double.MIN_VALUE}) {
+      assertEquals(v, BytesUtils.bytesToDouble(BytesUtils.doubleToBytes(v)), 0.0d);
+    }
+  }
+
+  @Test
+  public void testShortRoundTrip() {
+    for (short v : new short[] {0, 1, -1, 12345, Short.MAX_VALUE, Short.MIN_VALUE}) {
+      assertEquals(v, BytesUtils.bytesToShort(BytesUtils.shortToBytes(v)));
+    }
+  }
+
+  @Test
+  public void testBoolRoundTrip() {
+    assertTrue(BytesUtils.bytesToBool(BytesUtils.boolToBytes(true)));
+    assertFalse(BytesUtils.bytesToBool(BytesUtils.boolToBytes(false)));
+    assertTrue(BytesUtils.byteToBool(BytesUtils.boolToByte(true)));
+    assertFalse(BytesUtils.byteToBool(BytesUtils.boolToByte(false)));
+  }
+
+  @Test
+  public void testStringRoundTrip() {
+    for (String v : new String[] {"", "hello", "时序数据库", "a b\tc"}) {
+      assertEquals(v, BytesUtils.bytesToString(BytesUtils.stringToBytes(v)));
+    }
+  }
+
+  @Test
+  public void testTwoBytesRoundTrip() {
+    // values < 2^15 so signed/unsigned interpretation cannot diverge
+    for (int v : new int[] {0, 1, 255, 256, 30000}) {
+      assertEquals(v, BytesUtils.twoBytesToInt(BytesUtils.intToTwoBytes(v)));
+    }
+  }
+
+  @Test
+  public void testConcatAndSubBytes() {
+    byte[] a = {1, 2, 3};
+    byte[] b = {4, 5};
+    byte[] c = BytesUtils.concatByteArray(a, b);
+    assertArrayEquals(new byte[] {1, 2, 3, 4, 5}, c);
+    assertArrayEquals(new byte[] {2, 3, 4}, BytesUtils.subBytes(c, 1, 3));
+    assertNull("out-of-range returns null", BytesUtils.subBytes(c, 3, 10));
+    assertNull("non-positive length returns null", BytesUtils.subBytes(c, 0, 0));
+  }
+
+  @Test
+  public void testSetGetIntBit() {
+    int data = BytesUtils.setIntN(0, 4, 1);
+    assertEquals(16, data);
+    assertEquals(1, BytesUtils.getIntN(data, 4));
+    assertEquals(0, BytesUtils.getIntN(data, 3));
+    assertEquals(0, BytesUtils.getIntN(BytesUtils.setIntN(data, 4, 0), 4));
+  }
+}


### PR DESCRIPTION
## 问题
`BytesUtils.twoBytesToInt` 在合并两个字节时直接 `|=`,未对低字节做 `& 0xFF`,导致任何 >= 128 的低字节(如数值 255)被符号扩展,解码出负数。紧邻其下的 `bytesToInt` 已正确做了掩码。

## 改动
对参与拼接的字节加 `& 0xFF` 掩码。该方法当前无生产调用方,新增的往返(round-trip)测试用于守护此修复。

## 验证
新增 `BytesUtilsTest`(基础类型编解码、subBytes/concat、位运算往返)共 10 例通过;spotless 通过。

## 说明
基于 `master` 的独立分支,独立测试(不依赖 `BenchmarkTestBase`)。
