### PR TITLE
chore(core): 去除冗余的 surefire benchmark-conf 配置

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -113,28 +113,5 @@
       <version>5.5.2</version>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.4</version>
-        <configuration>
-          <!--
-            Tests trigger ConfigDescriptor, which resolves config.properties and
-            function.xml relative to "benchmark-conf" (default: configuration/conf).
-            Surefire forks with workingDirectory=core/, where these files don't
-            exist, so Config.initInnerFunction() hits a missing function.xml and
-            calls System.exit(0) (crashing the fork). Point benchmark-conf at the
-            repo-root config dir so the files resolve. The root config.properties
-            is fully commented out, so config stays at defaults.
-          -->
-          <systemPropertyVariables>
-            <benchmark-conf>${project.parent.basedir}/configuration/conf</benchmark-conf>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>


### PR DESCRIPTION
## 内容
构建 / 测试基建去重，无业务代码改动。

`function.xml` 缺失导致 `Config.initInnerFunction()` 调 `System.exit(0)` 把 surefire fork 杀掉的问题，现在有两套修复并存：

- #529 在 `core/pom.xml` 用 surefire `<systemPropertyVariables><benchmark-conf>` 设置（仅 `mvn test` 生效，但覆盖所有测试）。
- #536 的 `BenchmarkTestBase` 静态块用 `System.setProperty(... if==null)` 设置（maven + IDE 都生效，覆盖继承它的测试）。

所有会触发 `ConfigDescriptor` 的测试都已 `extends BenchmarkTestBase`，不继承它的测试根本不碰 `ConfigDescriptor`。在 `mvn test` 里 surefire 在 JVM 启动就设好属性，使 `BenchmarkTestBase` 的 `if==null` 永远为 false（成了 no-op）。即两套机制做同一件事，且 `BenchmarkTestBase` 更完整（额外覆盖 IDE）。

本 PR 删除 `core/pom.xml` 里的 surefire 插件块（JaCoCo 移除后它已是唯一插件），保留 `BenchmarkTestBase` 作为单一机制。

## 验证
- `mvn test -pl core`：38 tests 通过（默认顺序与 alphabetical 均通过）。
- `mvn spotless:check -pl core`：clean。