### PR TITLE
chore(core): trim stale comments in DBWrapper and SingletonWorkDataWorkLoad

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/DBWrapper.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/tsdb/DBWrapper.java
@@ -525,8 +525,6 @@ public class DBWrapper implements IDatabase {
         LOGGER.error("No device summary obtained from any database.");
         return null;
       }
-      // deviceSummary now holds the agreed-upon summary (non-null), so the final log and return
-      // below are safe; previously the last loop iteration could leave it null and NPE.
       deviceSummary = deviceSummaries.get(0);
       for (int i = 1; i < deviceSummaries.size(); i++) {
         if (!deviceSummary.equals(deviceSummaries.get(i))) {

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/workload/SingletonWorkDataWorkLoad.java
@@ -87,10 +87,8 @@ public class SingletonWorkDataWorkLoad extends GenerateDataWorkLoad {
         sensors = SENSORS;
       } else {
         // Derive the sensor cursor from the SAME curLoop reserved above so the (device, sensor)
-        // pairing is atomic: a single insertLoop.getAndIncrement() fixes both. A separate counter
-        // could be incremented by a concurrent caller between the two reads, mis-pairing the device
-        // with another caller's sensor (defect #3). Single-threaded this yields the same sequence,
-        // because insertLoop and the old sensor counter advanced in lockstep on this branch.
+        // pairing is atomic. With two independent counters a concurrent caller could increment
+        // the sensor counter between reads, mis-pairing this device with another caller's sensor.
         int sensorId = (int) ((curLoop - insertStartIndex) % config.getSENSOR_NUMBER());
         batch.setColIndex(sensorId);
         sensors.add(SENSORS.get(sensorId));


### PR DESCRIPTION
## Summary

Two stale-comment cleanups in core, surfaced in a Staff-Engineer-style review of the recent #533–#537 batch. No behavior change.

- **`DBWrapper#deviceSummary`** — drop the "previously the last loop iteration would NPE" note. The code now short-circuits on `deviceSummaries.isEmpty()` and picks `[0]` as the comparison base; the historical note no longer adds information.
- **`SingletonWorkDataWorkLoad#getOneBatch`** — drop the `(defect #3)` PR back-reference and the single-threaded equivalence trivia from the sensor-cursor comment. Keep the actionable WHY: two independent counters can be raced between the device and sensor reads, mis-pairing them.

Both comments hit project conventions in `CLAUDE.md`:
> Don't reference the current task, fix, or callers […] since those belong in the PR description and rot as the codebase evolves.

## Test plan

- [x] `mvn -pl core spotless:check`
- [x] `mvn -pl core compile`
- [x] CI green