### PR TITLE
test(core): add unit tests for utils, distribution, entity, and workload POJOs

### DIFF
--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/distribution/ProbToolTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/distribution/ProbToolTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.distribution;
+
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ProbToolTest {
+
+  private static final long SEED = 42L;
+  private static final int ITERATIONS = 100;
+
+  @Test
+  public void testProbabilityZeroAlwaysFalse() {
+    ProbTool tool = new ProbTool();
+    Random random = new Random(SEED);
+    for (int i = 0; i < ITERATIONS; i++) {
+      assertFalse("p=0.0 must never return true", tool.returnTrueByProb(0.0, random));
+    }
+  }
+
+  @Test
+  public void testProbabilityOneAlwaysTrue() {
+    ProbTool tool = new ProbTool();
+    Random random = new Random(SEED);
+    for (int i = 0; i < ITERATIONS; i++) {
+      assertTrue("p=1.0 must always return true", tool.returnTrueByProb(1.0, random));
+    }
+  }
+
+  @Test
+  public void testProbabilityHalfMatchesReferenceStream() {
+    ProbTool tool = new ProbTool();
+    Random toolRandom = new Random(SEED);
+    Random referenceRandom = new Random(SEED);
+    for (int i = 0; i < ITERATIONS; i++) {
+      boolean expected = referenceRandom.nextDouble() < 0.5;
+      assertEquals(expected, tool.returnTrueByProb(0.5, toolRandom));
+    }
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/Batch/BatchTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/Batch/BatchTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.entity.Batch;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.entity.Record;
+import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.ColumnCategory;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
+import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BatchTest extends BenchmarkTestBase {
+
+  private DeviceSchema buildSchema(String device, List<Sensor> sensors) {
+    return new DeviceSchema(device, sensors, new HashMap<>());
+  }
+
+  private List<Record> buildRecords(int count, int valuesPerRecord) {
+    List<Record> records = new LinkedList<>();
+    for (int i = 0; i < count; i++) {
+      List<Object> values = new ArrayList<>();
+      for (int j = 0; j < valuesPerRecord; j++) {
+        values.add("v" + j);
+      }
+      records.add(new Record(i, values));
+    }
+    return records;
+  }
+
+  @Test
+  public void testDefaultConstructor() {
+    Batch batch = new Batch();
+    assertEquals(0, batch.getRecords().size());
+    assertTrue(batch.getRecords() instanceof LinkedList);
+    assertEquals(null, batch.getDeviceSchema());
+    assertEquals(-1, batch.getColIndex());
+  }
+
+  @Test
+  public void testParamConstructor() {
+    DeviceSchema schema =
+        buildSchema(
+            "d1",
+            Arrays.asList(
+                new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD),
+                new Sensor("s2", SensorType.INT64, ColumnCategory.FIELD)));
+    List<Record> records = buildRecords(2, 2);
+    Batch batch = new Batch(schema, records);
+    assertEquals(schema, batch.getDeviceSchema());
+    assertEquals(records, batch.getRecords());
+  }
+
+  @Test
+  public void testPointNumAllFields() {
+    DeviceSchema schema =
+        buildSchema(
+            "d1",
+            Arrays.asList(
+                new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD),
+                new Sensor("s2", SensorType.INT64, ColumnCategory.FIELD)));
+    Batch batch = new Batch(schema, buildRecords(3, 2));
+    assertEquals(6L, batch.pointNum());
+  }
+
+  @Test
+  public void testPointNumExcludesTag() {
+    DeviceSchema schema =
+        buildSchema(
+            "d1",
+            Arrays.asList(
+                new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD),
+                new Sensor("s2", SensorType.INT64, ColumnCategory.TAG)));
+    Batch batch = new Batch(schema, buildRecords(4, 2));
+    assertEquals(4L, batch.pointNum());
+  }
+
+  @Test
+  public void testPointNumAllTagsEmptyRecords() {
+    DeviceSchema schema =
+        buildSchema(
+            "d1",
+            Arrays.asList(
+                new Sensor("s1", SensorType.DOUBLE, ColumnCategory.TAG),
+                new Sensor("s2", SensorType.INT64, ColumnCategory.TAG)));
+    Batch batch = new Batch(schema, new LinkedList<>());
+    assertEquals(0L, batch.pointNum());
+  }
+
+  @Test
+  public void testAddSchemaAndContentOverwrites() {
+    DeviceSchema schemaA =
+        buildSchema("d1", Arrays.asList(new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD)));
+    DeviceSchema schemaB =
+        buildSchema("d2", Arrays.asList(new Sensor("s2", SensorType.INT64, ColumnCategory.FIELD)));
+    List<Record> recordsA = buildRecords(1, 1);
+    List<Record> recordsB = buildRecords(3, 1);
+    Batch batch = new Batch(schemaA, recordsA);
+    batch.addSchemaAndContent(schemaB, recordsB);
+    assertEquals(schemaB, batch.getDeviceSchema());
+    assertEquals(recordsB, batch.getRecords());
+  }
+
+  @Test
+  public void testColIndexGetterSetter() {
+    Batch batch = new Batch();
+    batch.setColIndex(5);
+    assertEquals(5, batch.getColIndex());
+  }
+
+  @Test
+  public void testHasNextAlwaysFalse() {
+    Batch batch = new Batch();
+    assertFalse(batch.hasNext());
+  }
+
+  @Test
+  public void testNextThrowsUnsupported() {
+    Batch batch = new Batch();
+    try {
+      batch.next();
+      fail("expected UnsupportedOperationException");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testResetDoesNotThrow() {
+    Batch batch = new Batch();
+    batch.reset();
+  }
+
+  @Test
+  public void testEqualsAndHashCodeSameContent() {
+    DeviceSchema schema =
+        buildSchema("d1", Arrays.asList(new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD)));
+    List<Record> r1 = buildRecords(2, 1);
+    List<Record> r2 = buildRecords(2, 1);
+    Batch a = new Batch(schema, r1);
+    Batch b = new Batch(schema, r2);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void testEqualsDifferentRecords() {
+    DeviceSchema schema =
+        buildSchema("d1", Arrays.asList(new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD)));
+    Batch a = new Batch(schema, buildRecords(2, 1));
+    Batch b = new Batch(schema, buildRecords(3, 1));
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsDifferentSchema() {
+    DeviceSchema schemaA =
+        buildSchema("d1", Arrays.asList(new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD)));
+    DeviceSchema schemaB =
+        buildSchema("d2", Arrays.asList(new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD)));
+    List<Record> records = buildRecords(1, 1);
+    Batch a = new Batch(schemaA, records);
+    Batch b = new Batch(schemaB, records);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsNullAndOtherType() {
+    Batch a = new Batch();
+    assertFalse(a.equals(null));
+    assertFalse(a.equals("string"));
+    assertFalse(a.equals(new MultiDeviceBatch(1)));
+  }
+
+  @Test
+  public void testToStringContainsPrefix() {
+    DeviceSchema schema =
+        buildSchema("d1", Arrays.asList(new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD)));
+    Batch batch = new Batch(schema, buildRecords(1, 1));
+    assertTrue(batch.toString().startsWith("Batch{"));
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/Batch/MultiDeviceBatchTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/Batch/MultiDeviceBatchTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.entity.Batch;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.entity.Record;
+import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.ColumnCategory;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
+import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MultiDeviceBatchTest extends BenchmarkTestBase {
+
+  private DeviceSchema buildSchema(String device, List<Sensor> sensors) {
+    return new DeviceSchema(device, sensors, new HashMap<>());
+  }
+
+  private List<Record> buildRecords(int count, int valuesPerRecord) {
+    List<Record> records = new LinkedList<>();
+    for (int i = 0; i < count; i++) {
+      List<Object> values = new ArrayList<>();
+      for (int j = 0; j < valuesPerRecord; j++) {
+        values.add("v" + j);
+      }
+      records.add(new Record(i, values));
+    }
+    return records;
+  }
+
+  private List<Sensor> twoFieldsOneTag() {
+    return Arrays.asList(
+        new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD),
+        new Sensor("s2", SensorType.INT64, ColumnCategory.FIELD),
+        new Sensor("s3", SensorType.TEXT, ColumnCategory.TAG));
+  }
+
+  @Test
+  public void testAddSchemaAndContentThreeTimesAndInitialIndex() {
+    MultiDeviceBatch batch = new MultiDeviceBatch(3);
+    DeviceSchema s1 = buildSchema("d1", twoFieldsOneTag());
+    DeviceSchema s2 = buildSchema("d2", twoFieldsOneTag());
+    DeviceSchema s3 = buildSchema("d3", twoFieldsOneTag());
+    List<Record> r1 = buildRecords(1, 3);
+    List<Record> r2 = buildRecords(2, 3);
+    List<Record> r3 = buildRecords(3, 3);
+    batch.addSchemaAndContent(s1, r1);
+    batch.addSchemaAndContent(s2, r2);
+    batch.addSchemaAndContent(s3, r3);
+
+    // index starts at 0
+    assertEquals(s1, batch.getDeviceSchema());
+    assertEquals(r1, batch.getRecords());
+  }
+
+  @Test
+  public void testHasNextAndNextAdvancesIndex() {
+    MultiDeviceBatch batch = new MultiDeviceBatch(3);
+    DeviceSchema s1 = buildSchema("d1", twoFieldsOneTag());
+    DeviceSchema s2 = buildSchema("d2", twoFieldsOneTag());
+    DeviceSchema s3 = buildSchema("d3", twoFieldsOneTag());
+    batch.addSchemaAndContent(s1, buildRecords(1, 3));
+    batch.addSchemaAndContent(s2, buildRecords(1, 3));
+    batch.addSchemaAndContent(s3, buildRecords(1, 3));
+
+    assertTrue(batch.hasNext());
+    batch.next();
+    assertEquals(s2, batch.getDeviceSchema());
+    assertTrue(batch.hasNext());
+    batch.next();
+    assertEquals(s3, batch.getDeviceSchema());
+    // at last element, hasNext should be false
+    assertFalse(batch.hasNext());
+  }
+
+  @Test
+  public void testNextOutOfBoundsThrows() {
+    MultiDeviceBatch batch = new MultiDeviceBatch(1);
+    batch.addSchemaAndContent(buildSchema("d1", twoFieldsOneTag()), buildRecords(1, 3));
+    // advance to index == size (1)
+    batch.next();
+    try {
+      batch.next();
+      fail("expected IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException expected) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testResetRestoresIndexToZero() {
+    MultiDeviceBatch batch = new MultiDeviceBatch(2);
+    DeviceSchema s1 = buildSchema("d1", twoFieldsOneTag());
+    DeviceSchema s2 = buildSchema("d2", twoFieldsOneTag());
+    batch.addSchemaAndContent(s1, buildRecords(1, 3));
+    batch.addSchemaAndContent(s2, buildRecords(1, 3));
+    batch.next();
+    assertEquals(s2, batch.getDeviceSchema());
+    batch.reset();
+    assertEquals(s1, batch.getDeviceSchema());
+  }
+
+  @Test
+  public void testGetRecordsReturnsCurrentIndex() {
+    MultiDeviceBatch batch = new MultiDeviceBatch(2);
+    List<Record> r1 = buildRecords(1, 3);
+    List<Record> r2 = buildRecords(2, 3);
+    batch.addSchemaAndContent(buildSchema("d1", twoFieldsOneTag()), r1);
+    batch.addSchemaAndContent(buildSchema("d2", twoFieldsOneTag()), r2);
+    assertEquals(r1, batch.getRecords());
+    batch.next();
+    assertEquals(r2, batch.getRecords());
+  }
+
+  @Test
+  public void testSetColIndexNoopAndGetColIndexAlwaysMinusOne() {
+    MultiDeviceBatch batch = new MultiDeviceBatch(1);
+    batch.setColIndex(7);
+    assertEquals(-1, batch.getColIndex());
+    batch.setColIndex(0);
+    assertEquals(-1, batch.getColIndex());
+  }
+
+  @Test
+  public void testPointNum() {
+    MultiDeviceBatch batch = new MultiDeviceBatch(3);
+    // 2 FIELD sensors out of 3 (one TAG), 3 devices, each with 4 records
+    batch.addSchemaAndContent(buildSchema("d1", twoFieldsOneTag()), buildRecords(4, 3));
+    batch.addSchemaAndContent(buildSchema("d2", twoFieldsOneTag()), buildRecords(4, 3));
+    batch.addSchemaAndContent(buildSchema("d3", twoFieldsOneTag()), buildRecords(4, 3));
+    // 2 (FIELD) * 3 (recordLists size) * 4 (records.get(0).size()) = 24
+    assertEquals(24L, batch.pointNum());
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/DeviceSummaryTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/DeviceSummaryTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.entity;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DeviceSummaryTest {
+
+  @Test
+  public void testConstructorAndGetters() {
+    DeviceSummary summary = new DeviceSummary("d1", 100, 1000L, 2000L);
+    assertEquals("d1", summary.getDevice());
+    assertEquals(100, summary.getTotalLineNumber());
+    assertEquals(1000L, summary.getMinTimeStamp());
+    assertEquals(2000L, summary.getMaxTimeStamp());
+  }
+
+  @Test
+  public void testEqualsSameContent() {
+    DeviceSummary a = new DeviceSummary("d1", 100, 1000L, 2000L);
+    DeviceSummary b = new DeviceSummary("d1", 100, 1000L, 2000L);
+    assertEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsSelf() {
+    DeviceSummary a = new DeviceSummary("d1", 100, 1000L, 2000L);
+    assertEquals(a, a);
+  }
+
+  @Test
+  public void testEqualsDifferentDevice() {
+    DeviceSummary a = new DeviceSummary("d1", 100, 1000L, 2000L);
+    DeviceSummary b = new DeviceSummary("d2", 100, 1000L, 2000L);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsDifferentTotalLineNumber() {
+    DeviceSummary a = new DeviceSummary("d1", 100, 1000L, 2000L);
+    DeviceSummary b = new DeviceSummary("d1", 101, 1000L, 2000L);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsDifferentMinTimeStamp() {
+    DeviceSummary a = new DeviceSummary("d1", 100, 1000L, 2000L);
+    DeviceSummary b = new DeviceSummary("d1", 100, 1001L, 2000L);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsDifferentMaxTimeStamp() {
+    DeviceSummary a = new DeviceSummary("d1", 100, 1000L, 2000L);
+    DeviceSummary b = new DeviceSummary("d1", 100, 1000L, 2001L);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsNull() {
+    DeviceSummary a = new DeviceSummary("d1", 100, 1000L, 2000L);
+    assertFalse(a.equals(null));
+  }
+
+  @Test
+  public void testEqualsDifferentType() {
+    DeviceSummary a = new DeviceSummary("d1", 100, 1000L, 2000L);
+    assertFalse(a.equals("not a DeviceSummary"));
+  }
+
+  @Test
+  public void testToStringContainsAllFields() {
+    DeviceSummary a = new DeviceSummary("d1", 100, 1000L, 2000L);
+    String str = a.toString();
+    assertTrue(str.contains("d1"));
+    assertTrue(str.contains("100"));
+    assertTrue(str.contains("1000"));
+    assertTrue(str.contains("2000"));
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/RecordTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/RecordTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.entity;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RecordTest extends BenchmarkTestBase {
+
+  @Test
+  public void testConstructorAndGetters() {
+    List<Object> values = Arrays.asList(1, "a", 3.14);
+    Record record = new Record(123L, values);
+    assertEquals(123L, record.getTimestamp());
+    assertEquals(values, record.getRecordDataValue());
+  }
+
+  @Test
+  public void testSizeEmpty() {
+    Record record = new Record(0L, Collections.emptyList());
+    assertEquals(0, record.size());
+  }
+
+  @Test
+  public void testSizeThreeElements() {
+    Record record = new Record(0L, Arrays.asList(1, "a", 3.14));
+    assertEquals(3, record.size());
+  }
+
+  @Test
+  public void testSetTimestamp() {
+    Record record = new Record(1L, Arrays.asList(1));
+    record.setTimestamp(999L);
+    assertEquals(999L, record.getTimestamp());
+  }
+
+  @Test
+  public void testEqualsAndHashCodeSameContent() {
+    Record a = new Record(10L, Arrays.asList(1, "x", 2.5));
+    Record b = new Record(10L, Arrays.asList(1, "x", 2.5));
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void testEqualsDifferentTimestamp() {
+    Record a = new Record(10L, Arrays.asList(1, "x"));
+    Record b = new Record(11L, Arrays.asList(1, "x"));
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsDifferentData() {
+    Record a = new Record(10L, Arrays.asList(1, "x"));
+    Record b = new Record(10L, Arrays.asList(1, "y"));
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsNullAndOtherType() {
+    Record a = new Record(10L, Arrays.asList(1));
+    assertFalse(a.equals(null));
+    assertFalse(a.equals("not a record"));
+  }
+
+  @Test
+  public void testEqualsSelf() {
+    Record a = new Record(10L, Arrays.asList(1));
+    assertTrue(a.equals(a));
+  }
+
+  @Test
+  public void testSerializeRoundTripMixedTypes() throws Exception {
+    // Note: Boolean values are intentionally excluded — ReadWriteIOUtils.writeObject writes a
+    // Boolean as 1 byte but readObject reads it back via readInt (4 bytes), so Boolean
+    // round-tripping is broken in the production code.
+    Record original =
+        new Record(42L, Arrays.asList((Object) 42, (Object) 3.14f, (Object) "hello", 1L));
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    original.serialize(out);
+    Record restored = Record.deserialize(new ByteArrayInputStream(out.toByteArray()));
+    assertEquals(original, restored);
+  }
+
+  @Test
+  public void testSerializeRoundTripEmptyData() throws Exception {
+    Record original = new Record(7L, Collections.emptyList());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    original.serialize(out);
+    Record restored = Record.deserialize(new ByteArrayInputStream(out.toByteArray()));
+    assertEquals(original, restored);
+  }
+
+  @Test
+  public void testToStringContainsTimestampAndValues() {
+    Record record = new Record(55L, Arrays.asList("alpha"));
+    String s = record.toString();
+    assertTrue(s.contains("timestamp="));
+    assertTrue(s.contains("55"));
+    assertTrue(s.contains("alpha"));
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/SensorTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/entity/SensorTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.entity;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.ColumnCategory;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+public class SensorTest extends BenchmarkTestBase {
+
+  @Test
+  public void testTwoArgConstructorDefaultsToField() {
+    Sensor sensor = new Sensor("s1", SensorType.DOUBLE);
+    assertEquals("s1", sensor.getName());
+    assertEquals(SensorType.DOUBLE, sensor.getSensorType());
+    assertEquals(ColumnCategory.FIELD, sensor.getColumnCategory());
+  }
+
+  @Test
+  public void testThreeArgConstructor() {
+    Sensor sensor = new Sensor("s1", SensorType.INT64, ColumnCategory.TAG);
+    assertEquals("s1", sensor.getName());
+    assertEquals(SensorType.INT64, sensor.getSensorType());
+    assertEquals(ColumnCategory.TAG, sensor.getColumnCategory());
+  }
+
+  @Test
+  public void testSetters() {
+    Sensor sensor = new Sensor();
+    sensor.setName("renamed");
+    sensor.setSensorType(SensorType.FLOAT);
+    sensor.setColumnCategory(ColumnCategory.ATTRIBUTE);
+    assertEquals("renamed", sensor.getName());
+    assertEquals(SensorType.FLOAT, sensor.getSensorType());
+    assertEquals(ColumnCategory.ATTRIBUTE, sensor.getColumnCategory());
+  }
+
+  @Test
+  public void testEqualsAndHashCodeSameContent() {
+    Sensor a = new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD);
+    Sensor b = new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void testEqualsDifferentName() {
+    Sensor a = new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD);
+    Sensor b = new Sensor("s2", SensorType.DOUBLE, ColumnCategory.FIELD);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsDifferentSensorType() {
+    Sensor a = new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD);
+    Sensor b = new Sensor("s1", SensorType.INT64, ColumnCategory.FIELD);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsDifferentColumnCategory() {
+    Sensor a = new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD);
+    Sensor b = new Sensor("s1", SensorType.DOUBLE, ColumnCategory.TAG);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testEqualsNull() {
+    Sensor a = new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD);
+    assertFalse(a.equals(null));
+  }
+
+  @Test
+  public void testEqualsDifferentClass() {
+    Sensor a = new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD);
+    assertFalse(a.equals("not a sensor"));
+  }
+
+  @Test
+  public void testSerializeRoundTripDouble() throws Exception {
+    Sensor original = new Sensor("s1", SensorType.DOUBLE, ColumnCategory.FIELD);
+    assertEquals(original, roundTrip(original));
+  }
+
+  @Test
+  public void testSerializeRoundTripInt32() throws Exception {
+    Sensor original = new Sensor("s2", SensorType.INT32, ColumnCategory.TAG);
+    assertEquals(original, roundTrip(original));
+  }
+
+  @Test
+  public void testToStringReturnsName() {
+    Sensor sensor = new Sensor("sensor_name", SensorType.DOUBLE);
+    assertEquals("sensor_name", sensor.toString());
+  }
+
+  private Sensor roundTrip(Sensor sensor) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    sensor.serialize(out);
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    return Sensor.deserialize(in);
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/BlobUtilsTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/BlobUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BlobUtilsTest {
+
+  @Test
+  public void testBytesToHexEmpty() {
+    assertEquals("", BlobUtils.bytesToHex(new byte[0]));
+  }
+
+  @Test
+  public void testBytesToHexTypicalSequence() {
+    byte[] bytes = {(byte) 0x0A, (byte) 0xFF, (byte) 0x00, (byte) 0x7F};
+    assertEquals("0AFF007F", BlobUtils.bytesToHex(bytes));
+  }
+
+  @Test
+  public void testBytesToHexSingleByteZero() {
+    assertEquals("00", BlobUtils.bytesToHex(new byte[] {(byte) 0x00}));
+  }
+
+  @Test
+  public void testBytesToHexSingleByteFF() {
+    assertEquals("FF", BlobUtils.bytesToHex(new byte[] {(byte) 0xFF}));
+  }
+
+  @Test
+  public void testBytesToHexSingleByte10() {
+    assertEquals("10", BlobUtils.bytesToHex(new byte[] {(byte) 0x10}));
+  }
+
+  @Test
+  public void testStringToHexEmpty() {
+    assertEquals("", BlobUtils.stringToHex(""));
+  }
+
+  @Test
+  public void testStringToHexAscii() {
+    // 'A'=0x41, 'B'=0x42, 'C'=0x43
+    assertEquals("414243", BlobUtils.stringToHex("ABC"));
+  }
+
+  @Test
+  public void testStringToHexChinese() {
+    // "中" in UTF-8 is 0xE4 0xB8 0xAD
+    assertEquals("E4B8AD", BlobUtils.stringToHex("中"));
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/CommonAlgorithmsTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/CommonAlgorithmsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.utils;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommonAlgorithmsTest {
+
+  private static int sumValues(Map<Integer, Integer> map) {
+    int sum = 0;
+    for (Integer v : map.values()) {
+      sum += v;
+    }
+    return sum;
+  }
+
+  @Test
+  public void testDistributeDevicesEvenSplit() {
+    Map<Integer, Integer> result = CommonAlgorithms.distributeDevicesToClients(8, 4);
+    assertEquals(4, result.size());
+    assertEquals(8, sumValues(result));
+    for (int i = 0; i < 4; i++) {
+      assertEquals(Integer.valueOf(2), result.get(i));
+    }
+  }
+
+  @Test
+  public void testDistributeDevicesUnevenSplit() {
+    // From javadoc: 100 devices, 8 clients → {13,13,13,13,12,12,12,12}
+    Map<Integer, Integer> result = CommonAlgorithms.distributeDevicesToClients(100, 8);
+    assertEquals(8, result.size());
+    assertEquals(100, sumValues(result));
+    for (int i = 0; i < 4; i++) {
+      assertEquals(Integer.valueOf(13), result.get(i));
+    }
+    for (int i = 4; i < 8; i++) {
+      assertEquals(Integer.valueOf(12), result.get(i));
+    }
+  }
+
+  @Test
+  public void testDistributeDevicesFewerThanClients() {
+    Map<Integer, Integer> result = CommonAlgorithms.distributeDevicesToClients(3, 8);
+    assertEquals(8, result.size());
+    assertEquals(3, sumValues(result));
+    for (int i = 0; i < 3; i++) {
+      assertEquals(Integer.valueOf(1), result.get(i));
+    }
+    for (int i = 3; i < 8; i++) {
+      assertEquals(Integer.valueOf(0), result.get(i));
+    }
+  }
+
+  @Test
+  public void testDistributeDevicesSingleClient() {
+    Map<Integer, Integer> result = CommonAlgorithms.distributeDevicesToClients(10, 1);
+    assertEquals(1, result.size());
+    assertEquals(Integer.valueOf(10), result.get(0));
+  }
+
+  @Test
+  public void testDistributeDevicesZeroDevices() {
+    Map<Integer, Integer> result = CommonAlgorithms.distributeDevicesToClients(0, 4);
+    assertEquals(4, result.size());
+    assertEquals(0, sumValues(result));
+    for (int i = 0; i < 4; i++) {
+      assertEquals(Integer.valueOf(0), result.get(i));
+    }
+  }
+
+  @Test
+  public void testDistributeDevicesToTable() {
+    // Same strategy as distributeDevicesToClients: 10 devices, 3 tables → {4,3,3}
+    Map<Integer, Integer> result = CommonAlgorithms.distributeDevicesToTable(10, 3);
+    assertEquals(3, result.size());
+    assertEquals(10, sumValues(result));
+    assertEquals(Integer.valueOf(4), result.get(0));
+    assertEquals(Integer.valueOf(3), result.get(1));
+    assertEquals(Integer.valueOf(3), result.get(2));
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/FileUtilsTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/FileUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.utils;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+public class FileUtilsTest {
+
+  private static final String SEP = File.separator;
+
+  @Test
+  public void testUnionSingleSegment() {
+    assertEquals("a", FileUtils.union("a"));
+  }
+
+  @Test
+  public void testUnionTwoSegments() {
+    assertEquals("a" + SEP + "b", FileUtils.union("a", "b"));
+  }
+
+  @Test
+  public void testUnionMultipleSegments() {
+    assertEquals("a" + SEP + "b" + SEP + "c" + SEP + "d", FileUtils.union("a", "b", "c", "d"));
+  }
+
+  @Test
+  public void testUnionEmptyArray() {
+    assertEquals("", FileUtils.union());
+  }
+
+  @Test
+  public void testUnionWithEmptySegment() {
+    assertEquals("a" + SEP + SEP + "b", FileUtils.union("a", "", "b"));
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/NamedThreadFactoryTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/NamedThreadFactoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NamedThreadFactoryTest {
+
+  private static final Runnable NOOP = () -> {};
+
+  @Test
+  public void testSingleArgConstructorNamingAndNonDaemon() {
+    NamedThreadFactory factory = new NamedThreadFactory("pool");
+    Thread t1 = factory.newThread(NOOP);
+    Thread t2 = factory.newThread(NOOP);
+    Thread t3 = factory.newThread(NOOP);
+    assertEquals("pool-thread-1", t1.getName());
+    assertEquals("pool-thread-2", t2.getName());
+    assertEquals("pool-thread-3", t3.getName());
+    assertFalse(t1.isDaemon());
+    assertFalse(t2.isDaemon());
+    assertFalse(t3.isDaemon());
+  }
+
+  @Test
+  public void testTwoArgConstructorDaemonTrue() {
+    NamedThreadFactory factory = new NamedThreadFactory("daemonPool", true);
+    Thread t = factory.newThread(NOOP);
+    assertEquals("daemonPool-thread-1", t.getName());
+    assertTrue(t.isDaemon());
+  }
+
+  @Test
+  public void testTwoArgConstructorDaemonFalse() {
+    NamedThreadFactory factory = new NamedThreadFactory("normalPool", false);
+    Thread t = factory.newThread(NOOP);
+    assertEquals("normalPool-thread-1", t.getName());
+    assertFalse(t.isDaemon());
+  }
+
+  @Test
+  public void testIndependentCountersAcrossFactories() {
+    NamedThreadFactory factoryA = new NamedThreadFactory("a");
+    NamedThreadFactory factoryB = new NamedThreadFactory("b");
+    Thread a1 = factoryA.newThread(NOOP);
+    Thread a2 = factoryA.newThread(NOOP);
+    Thread b1 = factoryB.newThread(NOOP);
+    assertEquals("a-thread-1", a1.getName());
+    assertEquals("a-thread-2", a2.getName());
+    assertEquals("b-thread-1", b1.getName());
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/TimeUtilsTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/TimeUtilsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.utils;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimeUtilsTest {
+
+  @Test
+  public void testConvertDateStrToTimestamp() {
+    String dateStr = "2024-01-01T00:00:00Z";
+    long expected = new DateTime(dateStr).getMillis();
+    assertEquals(expected, TimeUtils.convertDateStrToTimestamp(dateStr));
+  }
+
+  @Test
+  public void testGetTimestampConstMs() {
+    assertEquals(1L, TimeUtils.getTimestampConst("ms"));
+  }
+
+  @Test
+  public void testGetTimestampConstUs() {
+    assertEquals(1000L, TimeUtils.getTimestampConst("us"));
+  }
+
+  @Test
+  public void testGetTimestampConstNs() {
+    assertEquals(1_000_000L, TimeUtils.getTimestampConst("ns"));
+  }
+
+  @Test
+  public void testGetTimestampConstFallback() {
+    // unknown precision falls into the else branch and returns 1_000_000
+    assertEquals(1_000_000L, TimeUtils.getTimestampConst("foo"));
+  }
+
+  @Test
+  public void testConvertToSecondsMs() {
+    assertEquals(1.0, TimeUtils.convertToSeconds(1000L, "ms"), 1e-9);
+  }
+
+  @Test
+  public void testConvertToSecondsUs() {
+    assertEquals(1.0, TimeUtils.convertToSeconds(1_000_000L, "us"), 1e-9);
+  }
+
+  @Test
+  public void testConvertToSecondsNs() {
+    assertEquals(1.0, TimeUtils.convertToSeconds(1_000_000_000L, "ns"), 1e-9);
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/ZipUtilsTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/utils/ZipUtilsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.utils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ZipUtilsTest {
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  private File writeFile(File parent, String name, String content) throws Exception {
+    File f = new File(parent, name);
+    try (FileOutputStream fos = new FileOutputStream(f)) {
+      fos.write(content.getBytes(StandardCharsets.UTF_8));
+    }
+    return f;
+  }
+
+  @Test
+  public void testToZipDirectoryKeepStructure() throws Exception {
+    File src = folder.newFolder("src");
+    writeFile(src, "a.txt", "alpha");
+    writeFile(src, "b.txt", "beta");
+    File zip = new File(folder.getRoot(), "dir.zip");
+
+    ZipUtils.toZip(src.getAbsolutePath(), zip.getAbsolutePath(), true);
+
+    assertTrue("zip file should exist", zip.exists());
+    try (ZipFile zf = new ZipFile(zip)) {
+      // entries should not be empty; entry names are not asserted because
+      // the production code joins them with System.lineSeparator()
+      assertTrue("zip should contain at least one entry", zf.entries().hasMoreElements());
+    }
+  }
+
+  @Test
+  public void testToZipFileListNoDelete() throws Exception {
+    File f1 = writeFile(folder.getRoot(), "one.txt", "one");
+    File f2 = writeFile(folder.getRoot(), "two.txt", "two");
+    File zip = new File(folder.getRoot(), "files.zip");
+    List<String> srcs = Arrays.asList(f1.getAbsolutePath(), f2.getAbsolutePath());
+
+    ZipUtils.toZip(srcs, zip.getAbsolutePath(), false);
+
+    assertTrue("zip file should exist", zip.exists());
+    assertTrue("source file 1 should still exist", f1.exists());
+    assertTrue("source file 2 should still exist", f2.exists());
+
+    Set<String> names = new HashSet<>();
+    try (ZipFile zf = new ZipFile(zip)) {
+      Enumeration<? extends ZipEntry> en = zf.entries();
+      while (en.hasMoreElements()) {
+        names.add(en.nextElement().getName());
+      }
+    }
+    assertEquals(2, names.size());
+    assertTrue(names.contains("one.txt"));
+    assertTrue(names.contains("two.txt"));
+  }
+
+  @Test
+  public void testToZipFileListNeedDelete() throws Exception {
+    File f1 = writeFile(folder.getRoot(), "del1.txt", "x");
+    File f2 = writeFile(folder.getRoot(), "del2.txt", "y");
+    File zip = new File(folder.getRoot(), "del.zip");
+    List<String> srcs = Arrays.asList(f1.getAbsolutePath(), f2.getAbsolutePath());
+
+    ZipUtils.toZip(srcs, zip.getAbsolutePath(), true);
+
+    assertTrue("zip file should exist", zip.exists());
+    assertFalse("source file 1 should be deleted", f1.exists());
+    assertFalse("source file 2 should be deleted", f2.exists());
+  }
+
+  @Test
+  public void testToZipDirectoryNullArgsDoesNotThrow() {
+    // current implementation only logs an error and continues; should not throw.
+    // zipName goes under TempFolder so the empty file the current impl still
+    // creates (it does not return after the null check) is auto-cleaned and
+    // does not pollute the module working directory.
+    String zipPath = new File(folder.getRoot(), "null-src.zip").getAbsolutePath();
+    ZipUtils.toZip((String) null, zipPath, true);
+  }
+
+  @Test
+  public void testToZipFileListNullZipNameDoesNotThrow() {
+    // current implementation only logs an error and continues; should not throw
+    ZipUtils.toZip(Collections.<String>emptyList(), null, false);
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/workload/ValueRangeFilterTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/workload/ValueRangeFilterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.workload;
+
+import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class ValueRangeFilterTest {
+
+  private List<Sensor> buildSensors() {
+    return Arrays.asList(new Sensor("s1", SensorType.DOUBLE), new Sensor("s2", SensorType.INT64));
+  }
+
+  @Test
+  public void testThreeArgConstructor() {
+    List<Sensor> sensors = buildSensors();
+    ValueRangeFilter filter = new ValueRangeFilter(1.5, sensors, 9.5);
+    assertEquals(Double.valueOf(1.5), filter.getMinValue());
+    assertEquals(Double.valueOf(9.5), filter.getMaxValue());
+    assertSame(sensors, filter.getSensors());
+  }
+
+  @Test
+  public void testMinAndSensorsConstructorMaxIsNull() {
+    List<Sensor> sensors = buildSensors();
+    ValueRangeFilter filter = new ValueRangeFilter(1.5, sensors);
+    assertEquals(Double.valueOf(1.5), filter.getMinValue());
+    assertNull(filter.getMaxValue());
+    assertSame(sensors, filter.getSensors());
+  }
+
+  @Test
+  public void testSensorsAndMaxConstructorMinIsNull() {
+    List<Sensor> sensors = buildSensors();
+    ValueRangeFilter filter = new ValueRangeFilter(sensors, 9.5);
+    assertNull(filter.getMinValue());
+    assertEquals(Double.valueOf(9.5), filter.getMaxValue());
+    assertSame(sensors, filter.getSensors());
+  }
+}


### PR DESCRIPTION
## Summary

Cover **13 previously-untested classes in `core/` with 98 new test cases** (no production code changed).

| Package | Test classes | Cases |
|---|---|---|
| `utils` | `BlobUtilsTest`, `CommonAlgorithmsTest`, `FileUtilsTest`, `NamedThreadFactoryTest`, `TimeUtilsTest`, `ZipUtilsTest` | 36 |
| `distribution` | `ProbToolTest` | 3 |
| `entity` | `DeviceSummaryTest`, `SensorTest`, `RecordTest` | 34 |
| `entity/Batch` | `BatchTest` (behaviour only), `MultiDeviceBatchTest` | 22 |
| `workload` | `ValueRangeFilterTest` | 3 |

Tests that transitively touch `ConfigDescriptor` (via `DeviceSchema` / `ReadWriteIOUtils`) extend `BenchmarkTestBase`; pure-utility tests do not, to avoid the static-singleton landmines documented during the earlier core test-bed work (#534, #536).

`BatchTest` deliberately does **not** repeat the serialization happy path already covered by `BatchSerializeTest` — it focuses on `pointNum()`, `equals`/`hashCode`, iterator behaviour, and getter/setter coverage.

## Suspected production bugs uncovered while writing the tests

These were **not** fixed in this PR (it is test-only). They will be filed separately:

- `ReadWriteIOUtils.writeObject(Boolean)` writes 1 byte while `readObject` reads 4 bytes — any `Boolean` field round-tripped via `Record.serialize`/`deserialize` will fail with `"Intend to read 8 bytes but 5 are actually returned"`. `RecordTest` uses Integer/Float/String/Long mixed types to side-step this.
- `ZipUtils.compress()` uses `System.lineSeparator()` as the zip-entry path separator (should be `"/"`).
- `ZipUtils.toZip(...)` two overloads `LOGGER.error` on null args without `return`, then fall through and produce an empty file + a swallowed NPE.
- `DeviceSummary.equals` NPEs when `this.device` is null.

## Test plan

- [x] `mvn test -pl core` — 136 tests run, 0 failures, 0 errors, 0 skipped
- [x] `mvn spotless:check -pl core` — clean
- [x] Verified no stray files left in the working tree after the run