### PR TITLE
chore(deps): bump vulnerable logback / postgresql / sqlite-jdbc to patched versions

### DIFF
--- a/iotdb-1.3/pom.xml
+++ b/iotdb-1.3/pom.xml
@@ -46,7 +46,7 @@
 
   <properties>
     <!-- This was the last version to support Java 8 -->
-    <logback.version>1.3.15</logback.version>
+    <logback.version>1.3.16</logback.version>
     <iotdb.version>1.3.7</iotdb.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <gson.version>2.10.1</gson.version>

--- a/iotdb-2.0/pom.xml
+++ b/iotdb-2.0/pom.xml
@@ -46,7 +46,7 @@
 
   <properties>
     <!-- This was the last version to support Java 8 -->
-    <logback.version>1.3.15</logback.version>
+    <logback.version>1.3.16</logback.version>
     <iotdb.version>2.0.8</iotdb.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <gson.version>2.10.1</gson.version>

--- a/questdb/pom.xml
+++ b/questdb/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.3</version>
+            <version>42.7.11</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.36.0.1</version>
+            <version>3.49.1.0</version>
         </dependency>
     </dependencies>
 

--- a/verification/pom.xml
+++ b/verification/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <version>1.2.13</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

Closes a wave of Dependabot alerts via small minor/patch bumps. Each bump stays on a release line that does not change public API for this project.

| Module | Dependency | Before → After | Dependabot alerts closed |
|---|---|---|---|
| `iotdb-2.0`, `iotdb-1.3` | `ch.qos.logback:logback-core` (via `logback.version`) | `1.3.15` → `1.3.16` | #41 #42 #46 #47 (ACE, class instantiation) |
| `verification` | `ch.qos.logback:logback-classic` | `1.2.11` → `1.2.13` | #20 (high — serialization) |
| `questdb` | `org.postgresql:postgresql` | `42.3.3` → `42.7.11` | #6 #12 #15 #19 #48 (incl. **critical** SQL injection GHSA-24rp-q3w6-vc56) |
| `sqlite` | `org.xerial:sqlite-jdbc` | `3.36.0.1` → `3.49.1.0` | #16 (high — RCE via attacker-controlled JDBC URL) |

### Why these specific versions

- **logback** — bumped to the latest patch on each release line we already use. We deliberately keep `verification` on `1.2.x` (rather than jumping to `1.3.x`) because the rest of the project is still on SLF4J 1.7 API, and logback `1.3.x` migrates to SLF4J 2.0 ServiceLoader binding. Mixing those would risk a runtime no-op logger binding.
- **postgresql** — `42.7.11` is the patched release for all five open advisories on the line we use; it stays on Java 8 compatible 42.7.x.
- **sqlite-jdbc** — `3.49.1.0` is the current latest on Maven Central; well past the `3.41.2.2` patched line for GHSA-6phf-6h5g-97j2. (Earlier proposal of `3.50.5.0` was wrong — that version does not exist on Maven Central yet.)

## Test plan

- [x] `mvn spotless:check` — pass
- [x] `mvn -B -pl core test` — **136 tests, 0 failures / 0 errors / 0 skipped**
- [x] `mvn -B clean install -DskipTests` — all 18 reactor modules SUCCESS
- [x] Artifact scan after `clean install`: confirmed `logback-core-1.3.16`, `logback-classic-1.2.13`, `postgresql-42.7.11`, `sqlite-jdbc-3.49.1.0` are in the assembled `lib/`; old vulnerable jars are no longer produced.

## Scope notes

This PR only changes patched-version bumps. Two follow-up PRs handle the rest of the open Dependabot wave:
1. Drop dead `kafka_2.10` + ancient `postgresql:postgresql:9.1` from `core` (zero Java references).
2. Replace `log4j:log4j:1.2.17` + `slf4j-log4j12` with `slf4j-reload4j` (log4j 1.x security fork), clearing the 6 remaining log4j 1.x advisories.

Out of scope here: `mysql-connector-java` upgrade — that one requires changes to the JDBC URL and driver class name in `core` source, so it will be a separate PR.