### PR TITLE
chore(deps): drop unused kafka_2.10 and obsolete postgresql JDBC4 from core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,11 +47,6 @@
       <version>1.21</version>
     </dependency>
     <dependency>
-      <groupId>postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>9.1-901-1.jdbc4</version>
-    </dependency>
-    <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <version>5.1.44</version>
@@ -75,21 +70,6 @@
       <groupId>com.clearspring.analytics</groupId>
       <artifactId>stream</artifactId>
       <version>2.9.8</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.10</artifactId>
-      <version>0.8.2.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
## Summary

Removes two long-dead dependencies from `core/pom.xml`. Both are historical leftovers with **zero Java references** anywhere in the project — only verifiable via \`grep -r\` because Dependabot only flagged one of them.

| Removed dependency | Why it can go | Alert closed |
|---|---|---|
| `org.apache.kafka:kafka_2.10:0.8.2.0` | Scala 2.10 build of Kafka 0.8; EOL for years; no Java code in this repo imports `org.apache.kafka.*` | #45 (GHSA-mcwh-c9pg-xw43, **high** — Kafka untrusted deserialization). No patched version exists on this artifact line, so removal is the only fix. |
| `postgresql:postgresql:9.1-901-1.jdbc4` | Pre-modern groupId (`postgresql`, not `org.postgresql`); zero Java references; the real PG driver lives in `questdb/pom.xml` and is being upgraded separately | Not Dependabot-flagged (legacy groupId slips the detector), but still a known-vulnerable artifact that was being shipped in every assembled `lib/`. |

## Test plan

- [x] `grep -rn --include='*.java' 'import org.apache.kafka\|import org.postgresql' core/src` → **0 hits**, confirming dead-code status
- [x] `mvn -B -pl core test` → **136 tests, 0 failures / 0 errors / 0 skipped**
- [x] `mvn -B clean install -DskipTests` → all 18 reactor modules SUCCESS
- [x] Verified `kafka_2.10-*.jar` and `postgresql-9.1-*.jar` no longer appear in any assembled `target/*/lib/` after rebuild.

## Scope notes

Independent of two sibling PRs landing the rest of the Dependabot wave:
- Patched-version bumps for logback / postgres / sqlite-jdbc.
- log4j 1.x → reload4j replacement.

`mysql-connector-java` upgrade is intentionally out of scope here — that one requires changes to the JDBC URL and driver class name in `core` source, so it will be a separate PR.