### PR TITLE
chore(deps): replace log4j 1.x with reload4j to clear 6 Dependabot advisories

### DIFF
--- a/cnosdb/pom.xml
+++ b/cnosdb/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/iginx/pom.xml
+++ b/iginx/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/influxdb-2.0/pom.xml
+++ b/influxdb-2.0/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
         <dependency>

--- a/influxdb/pom.xml
+++ b/influxdb/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/kairosdb/pom.xml
+++ b/kairosdb/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/mssqlserver/pom.xml
+++ b/mssqlserver/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
         <dependency>

--- a/opentsdb/pom.xml
+++ b/opentsdb/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/pi/pom.xml
+++ b/pi/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <spotless.skip>false</spotless.skip>
         <spotless.version>2.43.0</spotless.version>
         <google.java.format.version>1.22.0</google.java.format.version>
-        <org.slf4j.version>1.7.30</org.slf4j.version>
+        <org.slf4j.version>1.7.36</org.slf4j.version>
     </properties>
 
     <dependencies>
@@ -53,12 +53,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
         </dependency>
 
     </dependencies>

--- a/questdb/pom.xml
+++ b/questdb/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
         <dependency>

--- a/tdengine-3.0/pom.xml
+++ b/tdengine-3.0/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/tdengine/pom.xml
+++ b/tdengine/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/timescaledb-cluster/pom.xml
+++ b/timescaledb-cluster/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/timescaledb/pom.xml
+++ b/timescaledb/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>

--- a/verification/pom.xml
+++ b/verification/pom.xml
@@ -55,7 +55,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -83,7 +83,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -111,7 +111,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -139,7 +139,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -167,7 +167,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -195,7 +195,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -223,7 +223,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -263,7 +263,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -291,7 +291,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/victoriametrics/pom.xml
+++ b/victoriametrics/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary

\`log4j:log4j:1.2.17\` has been EOL since 2015 and keeps collecting advisories that will **never get a patched release on the 1.x line**. The project has **zero direct Java imports** of \`org.apache.log4j.*\` — \`log4j\` only sits in this repo as the runtime backend for \`slf4j-log4j12\` in every DB-adapter module's logging chain.

This PR removes \`log4j:log4j\` and swaps \`slf4j-log4j12\` → **\`slf4j-reload4j\`** across all 16 sub-modules. [\`reload4j\`](https://reload4j.qos.ch/) is the QOS.CH-maintained security fork of log4j 1.2 (same package: \`org.apache.log4j.*\`), so it's a **binary-compatible drop-in** — no source code changes needed.

### Why \`reload4j\` and not \`log4j-over-slf4j\`

An earlier draft of this PR proposed \`log4j-over-slf4j\` as the replacement. That would have been **wrong**: \`log4j-over-slf4j\` is a fake \`log4j\` that *redirects to SLF4J*, while \`slf4j-log4j12\` is an SLF4J binding that *forwards to log4j*. Pairing the two creates a SLF4J → log4j → SLF4J cycle (StackOverflowError at first log call). \`slf4j-reload4j\` is the right replacement — it's an SLF4J binding backed by \`reload4j\`, mirroring exactly what \`slf4j-log4j12\` + \`log4j:log4j\` did before.

## Changes

| File | Change |
|---|---|
| `pom.xml` | Drop `log4j:log4j:1.2.17` dependency; bump `org.slf4j.version` 1.7.30 → 1.7.36 (slf4j-reload4j was first released as part of SLF4J 1.7.32) |
| 16 sub-module poms | `<artifactId>slf4j-log4j12</artifactId>` → `<artifactId>slf4j-reload4j</artifactId>` (in `verification/pom.xml` the swap also applies inside several `<exclusion>` blocks that previously pinned the old binding) |

Modules touched: `cnosdb`, `iginx`, `influxdb`, `influxdb-2.0`, `kairosdb`, `mssqlserver`, `opentsdb`, `pi`, `questdb`, `sqlite`, `tdengine`, `tdengine-3.0`, `timescaledb`, `timescaledb-cluster`, `verification`, `victoriametrics`.

`core/pom.xml` is **not** touched here — its only `slf4j-log4j12` reference is inside the `<exclusion>` block on the dead `kafka_2.10` dependency, which is removed in a sibling PR.

## Test plan

- [x] `grep -rn 'import org.apache.log4j' --include='*.java'` → **0 hits** (confirms log4j is never used directly, so removing it can't break source compilation)
- [x] `mvn -B -pl core test` → **136 tests, 0 failures / 0 errors / 0 skipped**
- [x] `mvn -B clean install -DskipTests` → all 18 reactor modules SUCCESS
- [x] Post-build artifact scan:
  - `log4j-1.2.17.jar` count in any `target/*/lib/` → **0**
  - `reload4j-1.2.19.jar` count → **13** (every assembled module that previously shipped log4j)
  - `slf4j-reload4j-1.7.36.jar` count → **13**

## Dependabot alerts closed

All six log4j 1.x advisories — three **critical**, three **high**:
- GHSA-fp5r-v3w9-4333 (JMSAppender deserialization, high)
- GHSA-w9p3-5cr8-m3jj (Untrusted data deserialization, high)
- GHSA-65fg-84f6-3jq3 (SQL Injection, **critical**)
- GHSA-f7vh-qwp3-x37m (Untrusted data deserialization, **critical**)
- GHSA-2qrg-x229-3v8q (Untrusted data deserialization, **critical**)
- GHSA-vp98-w2p3-mv35 (DoS, high)

## Scope notes

Independent of the two sibling PRs covering the rest of the Dependabot wave:
- Patched-version bumps for logback / postgres / sqlite-jdbc.
- Drop dead `kafka_2.10` + ancient `postgresql:postgresql:9.1` from `core`.

`mysql-connector-java` upgrade is intentionally out of scope here — that one requires changes to the JDBC URL and driver class name in `core` source, so it will be a separate PR.