### PR TITLE
test(core): unit tests for real-data-set readers and schema loading

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchemaTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchemaTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.schema.schemaImpl;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.conf.Constants;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit test for {@link RealMetaDataSchema}'s {@code getAllFiles} walk, the most path-sensitive part
+ * of real-data-set schema loading. A real data set lays out one directory per device ({@code
+ * <root>/<device>/<file>.csv}) alongside top-level {@code schema.txt}/{@code info.txt} metadata.
+ * The walk must key every data file by its parent-directory device name and skip the two metadata
+ * files.
+ */
+public class RealMetaDataSchemaTest extends BenchmarkTestBase {
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  private File writeDeviceFile(String device) throws IOException {
+    File deviceDir = folder.newFolder(device);
+    File csv = new File(deviceDir, "BigBatch_0.csv");
+    try (BufferedWriter writer =
+        new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(csv), StandardCharsets.UTF_8))) {
+      writer.write("Sensor,s_0\n1000,1\n");
+    }
+    return csv;
+  }
+
+  @Test
+  public void getAllFilesKeysEachDataFileByDeviceDirAndSkipsMetadata() throws Exception {
+    File d0 = writeDeviceFile("d_0");
+    File d1 = writeDeviceFile("d_1");
+    // Metadata files live at the data-set root and must not be mistaken for device data files.
+    assertTrue(new File(folder.getRoot(), Constants.SCHEMA_PATH).createNewFile());
+    assertTrue(new File(folder.getRoot(), Constants.INFO_PATH).createNewFile());
+
+    Method getAllFiles =
+        RealMetaDataSchema.class.getDeclaredMethod("getAllFiles", String.class, Map.class);
+    getAllFiles.setAccessible(true);
+    Map<String, String> files = new LinkedHashMap<>();
+    getAllFiles.invoke(null, folder.getRoot().getAbsolutePath(), files);
+
+    assertEquals("only the two device files are mapped", 2, files.size());
+    assertEquals(d0.getAbsolutePath(), files.get("d_0"));
+    assertEquals(d1.getAbsolutePath(), files.get("d_1"));
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchemaTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/schema/schemaImpl/RealMetaDataSchemaTest.java
@@ -25,13 +25,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -50,13 +46,10 @@ public class RealMetaDataSchemaTest extends BenchmarkTestBase {
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   private File writeDeviceFile(String device) throws IOException {
+    // getAllFiles maps device -> path purely from directory structure; file content is never read.
     File deviceDir = folder.newFolder(device);
     File csv = new File(deviceDir, "BigBatch_0.csv");
-    try (BufferedWriter writer =
-        new BufferedWriter(
-            new OutputStreamWriter(new FileOutputStream(csv), StandardCharsets.UTF_8))) {
-      writer.write("Sensor,s_0\n1000,1\n");
-    }
+    assertTrue(csv.createNewFile());
     return csv;
   }
 

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReaderTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/source/CSVDataReaderTest.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.source;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.conf.Config;
+import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
+import cn.edu.tsinghua.iot.benchmark.entity.Batch.IBatch;
+import cn.edu.tsinghua.iot.benchmark.entity.Record;
+import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
+import cn.edu.tsinghua.iot.benchmark.mode.enums.BenchmarkMode;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaDataSchema;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
+import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link CSVDataReader} and the {@link DataReader#getInstance(List)} factory.
+ *
+ * <p>{@code CSVDataReader} reads one device per CSV file. The device name is the file's parent
+ * directory; the first CSV line is a header naming the sensors; the remaining lines are {@code
+ * timestamp,value,...} rows decoded according to each sensor's {@link SensorType} (the
+ * value-mapping is the real-data-set "data pattern" under test). The reader looks the device's
+ * sensor types up in the {@link MetaDataSchema} singleton, which this test populates by reflection
+ * so the test owns the schema rather than depending on generated devices.
+ */
+public class CSVDataReaderTest extends BenchmarkTestBase {
+
+  private static final Config config = ConfigDescriptor.getInstance().getConfig();
+
+  /** Unique device id well outside any generated range, so it never collides. */
+  private static final String DEVICE = "d_8000001";
+
+  private static final String HEADER = "Sensor,c_bool,c_int,c_long,c_float,c_double,c_text";
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  private Map<String, DeviceSchema> nameDataSchema;
+  private int origBatchSize;
+  private boolean origCopyMode;
+  private BenchmarkMode origWorkMode;
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setUp() throws Exception {
+    origBatchSize = config.getBATCH_SIZE_PER_WRITE();
+    origCopyMode = config.isIS_COPY_MODE();
+    origWorkMode = config.getBENCHMARK_WORK_MODE();
+
+    // CSVDataReader holds `static final metaDataSchema = MetaDataSchema.getInstance()`. Build the
+    // singleton now, in a non-verification mode, so the first build picks GenerateMetaDataSchema
+    // (RealMetaDataSchema would System.exit when FILE_PATH has no data set).
+    config.setBENCHMARK_WORK_MODE(BenchmarkMode.TEST_WITH_DEFAULT_PATH);
+    config.setIS_COPY_MODE(false);
+    MetaDataSchema.getInstance();
+
+    Field field = MetaDataSchema.class.getDeclaredField("NAME_DATA_SCHEMA");
+    field.setAccessible(true);
+    nameDataSchema = (Map<String, DeviceSchema>) field.get(null);
+
+    List<Sensor> sensors =
+        Arrays.asList(
+            new Sensor("c_bool", SensorType.BOOLEAN),
+            new Sensor("c_int", SensorType.INT32),
+            new Sensor("c_long", SensorType.INT64),
+            new Sensor("c_float", SensorType.FLOAT),
+            new Sensor("c_double", SensorType.DOUBLE),
+            new Sensor("c_text", SensorType.TEXT));
+    nameDataSchema.put(DEVICE, new DeviceSchema(DEVICE, sensors, MetaUtil.getTags(DEVICE)));
+  }
+
+  @After
+  public void tearDown() {
+    nameDataSchema.remove(DEVICE);
+    config.setBATCH_SIZE_PER_WRITE(origBatchSize);
+    config.setIS_COPY_MODE(origCopyMode);
+    config.setBENCHMARK_WORK_MODE(origWorkMode);
+  }
+
+  /** Writes {@code <root>/<device>/<device>.csv} with the shared header and the given data rows. */
+  private String writeDeviceCsv(String device, String... rows) throws IOException {
+    File deviceDir = folder.newFolder(device);
+    File csv = new File(deviceDir, device + ".csv");
+    try (BufferedWriter writer =
+        new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(csv), StandardCharsets.UTF_8))) {
+      writer.write(HEADER);
+      writer.write("\n");
+      for (String row : rows) {
+        writer.write(row);
+        writer.write("\n");
+      }
+    }
+    return csv.getAbsolutePath();
+  }
+
+  /** Writes {@code <root>/<device>/<device>.csv} verbatim, so the caller can embed header lines. */
+  private String writeRawDeviceCsv(String device, String content) throws IOException {
+    File deviceDir = folder.newFolder(device);
+    File csv = new File(deviceDir, device + ".csv");
+    try (BufferedWriter writer =
+        new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(csv), StandardCharsets.UTF_8))) {
+      writer.write(content);
+    }
+    return csv.getAbsolutePath();
+  }
+
+  /** Each CSV value is decoded to the Java type dictated by its sensor's {@link SensorType}. */
+  @Test
+  public void nextBatchDecodesEachValueToItsSensorType() throws IOException {
+    config.setBATCH_SIZE_PER_WRITE(100);
+    String csv =
+        writeDeviceCsv(
+            DEVICE, "1000,true,42,9999999999,1.5,2.5,hello", "2000,false,-7,-1,-3.5,-4.5,world");
+
+    DataReader reader = new CSVDataReader(Collections.singletonList(csv));
+    assertTrue(reader.hasNextBatch());
+    IBatch batch = reader.nextBatch();
+
+    assertEquals(DEVICE, batch.getDeviceSchema().getDevice());
+    List<Record> records = batch.getRecords();
+    assertEquals(2, records.size());
+
+    Record first = records.get(0);
+    assertEquals(1000L, first.getTimestamp());
+    List<Object> values = first.getRecordDataValue();
+    assertEquals(Boolean.TRUE, values.get(0));
+    assertEquals(Integer.valueOf(42), values.get(1));
+    assertEquals(Long.valueOf(9999999999L), values.get(2));
+    assertEquals(Float.valueOf(1.5f), values.get(3));
+    assertEquals(Double.valueOf(2.5d), values.get(4));
+    assertEquals("hello", values.get(5));
+
+    assertEquals(2000L, records.get(1).getTimestamp());
+
+    // One file with fewer rows than BATCH_SIZE is fully drained by a single batch.
+    assertFalse(reader.hasNextBatch());
+  }
+
+  /** {@code hasNextBatch}/{@code nextBatch} walk every file in order, one batch per file. */
+  @Test
+  public void iteratesAcrossMultipleDeviceFiles() throws IOException {
+    config.setBATCH_SIZE_PER_WRITE(100);
+    String fileA = writeDeviceCsv(DEVICE, "1,true,1,1,1.0,1.0,a");
+
+    // A second device. CSVDataReader builds the batch's DeviceSchema from the directory name, so
+    // the injected entry only needs to supply the matching sensor list for the type lookup.
+    String otherDevice = "d_8000002";
+    nameDataSchema.put(otherDevice, nameDataSchema.get(DEVICE));
+    String fileB = writeDeviceCsv(otherDevice, "2,false,2,2,2.0,2.0,b");
+
+    try {
+      DataReader reader = new CSVDataReader(Arrays.asList(fileA, fileB));
+      List<String> devicesSeen = new ArrayList<>();
+      while (reader.hasNextBatch()) {
+        devicesSeen.add(reader.nextBatch().getDeviceSchema().getDevice());
+      }
+      assertEquals(Arrays.asList(DEVICE, otherDevice), devicesSeen);
+    } finally {
+      nameDataSchema.remove(otherDevice);
+    }
+  }
+
+  /** The factory wires non-copy mode to {@link CSVDataReader}. */
+  @Test
+  public void getInstanceReturnsCsvDataReaderInNonCopyMode() throws IOException {
+    config.setIS_COPY_MODE(false);
+    String csv = writeDeviceCsv(DEVICE, "1,true,1,1,1.0,1.0,a");
+    DataReader reader = DataReader.getInstance(Collections.singletonList(csv));
+    assertTrue(reader instanceof CSVDataReader);
+  }
+
+  /** STRING, BLOB, DATE and TIMESTAMP decode to String, String, {@link LocalDate} and Long. */
+  @Test
+  public void nextBatchDecodesExtendedSensorTypes() throws IOException {
+    config.setBATCH_SIZE_PER_WRITE(100);
+    String device = "d_8000004";
+    nameDataSchema.put(
+        device,
+        new DeviceSchema(
+            device,
+            Arrays.asList(
+                new Sensor("s_str", SensorType.STRING),
+                new Sensor("s_blob", SensorType.BLOB),
+                new Sensor("s_date", SensorType.DATE),
+                new Sensor("s_ts", SensorType.TIMESTAMP)),
+            MetaUtil.getTags(device)));
+    try {
+      String csv =
+          writeRawDeviceCsv(
+              device,
+              "Sensor,s_str,s_blob,s_date,s_ts\n" + "1000,hello,bytes,2024-01-01,123456789\n");
+
+      DataReader reader = new CSVDataReader(Collections.singletonList(csv));
+      assertTrue(reader.hasNextBatch());
+      List<Object> values = reader.nextBatch().getRecords().get(0).getRecordDataValue();
+
+      assertEquals("hello", values.get(0));
+      assertEquals("bytes", values.get(1));
+      assertEquals(LocalDate.of(2024, 1, 1), values.get(2));
+      assertEquals(123456789L, values.get(3));
+    } finally {
+      nameDataSchema.remove(device);
+    }
+  }
+
+  /**
+   * {@code CSVDataWriter} re-emits the {@code Sensor} header before every written batch, so one
+   * device file holds several header-delimited segments. With {@code BATCH_SIZE} aligned to a
+   * segment's row count, the reader yields one batch per segment from the single file.
+   */
+  @Test
+  public void drainsHeaderDelimitedSegmentsAsSeparateBatches() throws IOException {
+    config.setBATCH_SIZE_PER_WRITE(2);
+    String csv =
+        writeRawDeviceCsv(
+            DEVICE,
+            HEADER
+                + "\n"
+                + "1000,true,1,1,1.0,1.0,a\n"
+                + "2000,false,2,2,2.0,2.0,b\n"
+                + HEADER
+                + "\n"
+                + "3000,true,3,3,3.0,3.0,c\n"
+                + "4000,false,4,4,4.0,4.0,d\n");
+
+    DataReader reader = new CSVDataReader(Collections.singletonList(csv));
+
+    assertTrue(reader.hasNextBatch());
+    List<Record> first = reader.nextBatch().getRecords();
+    assertEquals(2, first.size());
+    assertEquals(1000L, first.get(0).getTimestamp());
+    assertEquals(2000L, first.get(1).getTimestamp());
+
+    assertTrue(reader.hasNextBatch());
+    List<Record> second = reader.nextBatch().getRecords();
+    assertEquals(2, second.size());
+    assertEquals(3000L, second.get(0).getTimestamp());
+    assertEquals(4000L, second.get(1).getTimestamp());
+
+    assertFalse(reader.hasNextBatch());
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/source/CSVSchemaReaderTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/source/CSVSchemaReaderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.source;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.conf.Config;
+import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
+import cn.edu.tsinghua.iot.benchmark.conf.Constants;
+import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link CSVSchemaReader}, the reader that loads the schema of a real data set.
+ *
+ * <p>A real data set directory carries a {@code schema.txt} (one {@code device sensor typeOrdinal}
+ * triple per line) describing every device's sensors, and an {@code info.txt} snapshot of the
+ * generation config used to validate that the running benchmark matches the data set. Both files
+ * are resolved relative to {@code config.FILE_PATH}; this test points that at a temp folder.
+ */
+public class CSVSchemaReaderTest extends BenchmarkTestBase {
+
+  private static final Config config = ConfigDescriptor.getInstance().getConfig();
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  private String origFilePath;
+
+  @Before
+  public void setUp() {
+    origFilePath = config.getFILE_PATH();
+    config.setFILE_PATH(folder.getRoot().getAbsolutePath());
+  }
+
+  @After
+  public void tearDown() {
+    config.setFILE_PATH(origFilePath);
+  }
+
+  private void writeDataSetFile(String name, String content) throws IOException {
+    Files.write(
+        Paths.get(folder.getRoot().getAbsolutePath(), name),
+        content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * {@code getDeviceSchemaList} must group sensors under their device, keep insertion order, decode
+   * the third column as a {@link SensorType} ordinal, and skip blank lines.
+   */
+  @Test
+  public void getDeviceSchemaListParsesDevicesSensorsAndTypes() throws IOException {
+    // typeOrdinal: 0=BOOLEAN, 1=INT32, 4=DOUBLE, 5=TEXT (see SensorType declaration order)
+    writeDataSetFile(
+        Constants.SCHEMA_PATH,
+        "d_0 s_0 1\n" + "d_0 s_1 4\n" + "\n" + "d_1 s_0 0\n" + "d_1 s_1 5\n");
+
+    Map<String, List<Sensor>> result = new CSVSchemaReader().getDeviceSchemaList();
+
+    assertEquals("two distinct devices expected", 2, result.size());
+    // LinkedHashMap preserves the order devices first appear in the file.
+    Iterator<String> deviceOrder = result.keySet().iterator();
+    assertEquals("d_0", deviceOrder.next());
+    assertEquals("d_1", deviceOrder.next());
+
+    List<Sensor> d0 = result.get("d_0");
+    assertEquals(2, d0.size());
+    assertEquals("s_0", d0.get(0).getName());
+    assertEquals(SensorType.INT32, d0.get(0).getSensorType());
+    assertEquals("s_1", d0.get(1).getName());
+    assertEquals(SensorType.DOUBLE, d0.get(1).getSensorType());
+
+    List<Sensor> d1 = result.get("d_1");
+    assertEquals(2, d1.size());
+    assertEquals(SensorType.BOOLEAN, d1.get(0).getSensorType());
+    assertEquals(SensorType.TEXT, d1.get(1).getSensorType());
+  }
+
+  /** With no {@code info.txt} present the data set cannot be validated. */
+  @Test
+  public void checkDataSetReturnsFalseWhenInfoFileMissing() {
+    assertFalse(new CSVSchemaReader().checkDataSet());
+  }
+
+  /** An {@code info.txt} equal to the current config's snapshot validates successfully. */
+  @Test
+  public void checkDataSetReturnsTrueWhenInfoMatchesConfig() throws IOException {
+    writeDataSetFile(Constants.INFO_PATH, config.toInfoText());
+    assertTrue(new CSVSchemaReader().checkDataSet());
+  }
+
+  /** A single differing line (same line count) fails validation. */
+  @Test
+  public void checkDataSetReturnsFalseWhenInfoDiffersFromConfig() throws IOException {
+    String info = config.toInfoText();
+    String mutated = info.replaceFirst("LOOP=\\d+", "LOOP=" + (config.getLOOP() + 987654));
+    assertNotEquals("mutation must actually change the snapshot", info, mutated);
+    writeDataSetFile(Constants.INFO_PATH, mutated);
+    assertFalse(new CSVSchemaReader().checkDataSet());
+  }
+}

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReaderTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/source/CopyDataReaderTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cn.edu.tsinghua.iot.benchmark.source;
+
+import cn.edu.tsinghua.iot.benchmark.BenchmarkTestBase;
+import cn.edu.tsinghua.iot.benchmark.conf.Config;
+import cn.edu.tsinghua.iot.benchmark.conf.ConfigDescriptor;
+import cn.edu.tsinghua.iot.benchmark.entity.Batch.IBatch;
+import cn.edu.tsinghua.iot.benchmark.entity.Record;
+import cn.edu.tsinghua.iot.benchmark.entity.Sensor;
+import cn.edu.tsinghua.iot.benchmark.entity.enums.SensorType;
+import cn.edu.tsinghua.iot.benchmark.mode.enums.BenchmarkMode;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaDataSchema;
+import cn.edu.tsinghua.iot.benchmark.schema.MetaUtil;
+import cn.edu.tsinghua.iot.benchmark.schema.schemaImpl.DeviceSchema;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link CopyDataReader} and the copy-mode branch of {@link
+ * DataReader#getInstance(List)}.
+ *
+ * <p>Copy mode reads a single device file once at construction and then re-emits that batch {@code
+ * LOOP} times, advancing every timestamp by the file's time span ({@code last - first}) on each
+ * loop so the synthetic stream marches forward in time without re-reading from disk.
+ */
+public class CopyDataReaderTest extends BenchmarkTestBase {
+
+  private static final Config config = ConfigDescriptor.getInstance().getConfig();
+
+  private static final String DEVICE = "d_8000003";
+  private static final String HEADER = "Sensor,c_bool,c_int,c_long,c_float,c_double,c_text";
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  private Map<String, DeviceSchema> nameDataSchema;
+  private int origBatchSize;
+  private boolean origCopyMode;
+  private boolean origAnomaly;
+  private double origAnomalyRate;
+  private int origAnomalyTimes;
+  private long origLoop;
+  private BenchmarkMode origWorkMode;
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setUp() throws Exception {
+    origBatchSize = config.getBATCH_SIZE_PER_WRITE();
+    origCopyMode = config.isIS_COPY_MODE();
+    origAnomaly = config.isIS_ADD_ANOMALY();
+    origAnomalyRate = config.getANOMALY_RATE();
+    origAnomalyTimes = config.getANOMALY_TIMES();
+    origLoop = config.getLOOP();
+    origWorkMode = config.getBENCHMARK_WORK_MODE();
+
+    config.setBENCHMARK_WORK_MODE(BenchmarkMode.TEST_WITH_DEFAULT_PATH);
+    MetaDataSchema.getInstance();
+    config.setIS_COPY_MODE(true);
+    config.setIS_ADD_ANOMALY(false);
+    config.setBATCH_SIZE_PER_WRITE(100);
+
+    Field field = MetaDataSchema.class.getDeclaredField("NAME_DATA_SCHEMA");
+    field.setAccessible(true);
+    nameDataSchema = (Map<String, DeviceSchema>) field.get(null);
+
+    List<Sensor> sensors =
+        Arrays.asList(
+            new Sensor("c_bool", SensorType.BOOLEAN),
+            new Sensor("c_int", SensorType.INT32),
+            new Sensor("c_long", SensorType.INT64),
+            new Sensor("c_float", SensorType.FLOAT),
+            new Sensor("c_double", SensorType.DOUBLE),
+            new Sensor("c_text", SensorType.TEXT));
+    nameDataSchema.put(DEVICE, new DeviceSchema(DEVICE, sensors, MetaUtil.getTags(DEVICE)));
+  }
+
+  @After
+  public void tearDown() {
+    nameDataSchema.remove(DEVICE);
+    config.setBATCH_SIZE_PER_WRITE(origBatchSize);
+    config.setIS_COPY_MODE(origCopyMode);
+    config.setIS_ADD_ANOMALY(origAnomaly);
+    config.setANOMALY_RATE(origAnomalyRate);
+    config.setANOMALY_TIMES(origAnomalyTimes);
+    config.setLOOP(origLoop);
+    config.setBENCHMARK_WORK_MODE(origWorkMode);
+  }
+
+  private String writeDeviceCsv(String device, String... rows) throws IOException {
+    File deviceDir = folder.newFolder(device);
+    File csv = new File(deviceDir, device + ".csv");
+    try (BufferedWriter writer =
+        new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(csv), StandardCharsets.UTF_8))) {
+      writer.write(HEADER);
+      writer.write("\n");
+      for (String row : rows) {
+        writer.write(row);
+        writer.write("\n");
+      }
+    }
+    return csv.getAbsolutePath();
+  }
+
+  /** {@code hasNextBatch} yields exactly {@code LOOP} batches, then stops. */
+  @Test
+  public void emitsExactlyLoopBatches() throws IOException {
+    config.setLOOP(3);
+    String csv = writeDeviceCsv(DEVICE, "1000,true,1,1,1.0,1.0,a", "3000,false,2,2,2.0,2.0,b");
+
+    CopyDataReader reader = new CopyDataReader(Collections.singletonList(csv));
+    int batches = 0;
+    while (reader.hasNextBatch()) {
+      reader.nextBatch();
+      batches++;
+    }
+    assertEquals(3, batches);
+    assertFalse(reader.hasNextBatch());
+  }
+
+  /** Each loop advances every record's timestamp by the file's (last - first) span. */
+  @Test
+  public void shiftsTimestampsByFileSpanOnEachLoop() throws IOException {
+    config.setLOOP(2);
+    // span = 3000 - 1000 = 2000
+    String csv = writeDeviceCsv(DEVICE, "1000,true,1,1,1.0,1.0,a", "3000,false,2,2,2.0,2.0,b");
+
+    CopyDataReader reader = new CopyDataReader(Collections.singletonList(csv));
+
+    IBatch first = reader.nextBatch();
+    long firstRowAfterLoop1 = first.getRecords().get(0).getTimestamp();
+    long secondRowAfterLoop1 = first.getRecords().get(1).getTimestamp();
+    assertEquals(3000L, firstRowAfterLoop1);
+    assertEquals(5000L, secondRowAfterLoop1);
+
+    // nextBatch re-emits and mutates the same batch instance, advancing by the span again.
+    IBatch second = reader.nextBatch();
+    assertEquals(5000L, second.getRecords().get(0).getTimestamp());
+    assertEquals(7000L, second.getRecords().get(1).getTimestamp());
+  }
+
+  /** The factory wires copy mode to {@link CopyDataReader}. */
+  @Test
+  public void getInstanceReturnsCopyDataReaderInCopyMode() throws IOException {
+    config.setLOOP(1);
+    String csv = writeDeviceCsv(DEVICE, "1000,true,1,1,1.0,1.0,a");
+    DataReader reader = DataReader.getInstance(Collections.singletonList(csv));
+    assertTrue(reader instanceof CopyDataReader);
+  }
+
+  /**
+   * With anomaly injection on and a 100% rate, every emitted record is multiplied: numeric values
+   * scale by {@code ANOMALY_TIMES} while BOOLEAN/TEXT values and the per-loop timestamp shift are
+   * preserved.
+   */
+  @Test
+  public void injectsAnomaliesIntoNumericValuesWhenEnabled() throws IOException {
+    config.setLOOP(1);
+    config.setIS_ADD_ANOMALY(true);
+    config.setANOMALY_RATE(1.0);
+    config.setANOMALY_TIMES(2);
+    // span = 3000 - 1000 = 2000
+    String csv = writeDeviceCsv(DEVICE, "1000,true,1,2,3.0,4.0,x", "3000,false,5,6,7.0,8.0,y");
+
+    CopyDataReader reader = new CopyDataReader(Collections.singletonList(csv));
+    List<Record> records = reader.nextBatch().getRecords();
+    assertEquals(2, records.size());
+
+    List<Object> first = records.get(0).getRecordDataValue();
+    assertEquals(3000L, records.get(0).getTimestamp());
+    assertEquals(Boolean.TRUE, first.get(0));
+    assertEquals(Integer.valueOf(2), first.get(1));
+    assertEquals(Long.valueOf(4), first.get(2));
+    assertEquals(Float.valueOf(6.0f), first.get(3));
+    assertEquals(Double.valueOf(8.0d), first.get(4));
+    assertEquals("x", first.get(5));
+
+    List<Object> second = records.get(1).getRecordDataValue();
+    assertEquals(5000L, records.get(1).getTimestamp());
+    assertEquals(Boolean.FALSE, second.get(0));
+    assertEquals(Integer.valueOf(10), second.get(1));
+    assertEquals(Long.valueOf(12), second.get(2));
+    assertEquals(Float.valueOf(14.0f), second.get(3));
+    assertEquals(Double.valueOf(16.0d), second.get(4));
+    assertEquals("y", second.get(5));
+  }
+}


### PR DESCRIPTION
## Summary
Adds unit-test coverage for the CSV real-data-set input path in `core` (no production changes). One test class per production class under test:

- **`CSVSchemaReaderTest`** — `getDeviceSchemaList` parsing (device grouping, insertion order, `SensorType` ordinal decoding, blank-line skipping) and `checkDataSet` validation against `info.txt` (missing / matching / differing snapshot).
- **`CSVDataReaderTest`** — per-`SensorType` value decoding incl. `STRING`/`BLOB`/`DATE`/`TIMESTAMP`, iteration across multiple device files, draining multiple header-delimited batches from one file (the `CSVDataWriter` re-emits the `Sensor` header per batch), and non-copy-mode factory wiring.
- **`CopyDataReaderTest`** — `LOOP`-bounded batch count, per-loop timestamp shift by the file's time span, anomaly-injection scaling of numeric values, and copy-mode factory wiring.
- **`RealMetaDataSchemaTest`** — `getAllFiles` keys each data file by its parent-directory device name and skips `schema.txt` / `info.txt` metadata.

All schema/config-touching tests extend `BenchmarkTestBase` and save/restore mutated `Config` singleton state per the core-test conventions.

## Test plan
- [x] `mvn -pl core test -Dtest='CSVDataReaderTest,CopyDataReaderTest,CSVSchemaReaderTest,RealMetaDataSchemaTest'` → 14 run, 0 failures, 0 errors
- [x] `mvn -pl core spotless:check` → clean
- [ ] CI `core-test.yml` (JDK 8) green