### PR TITLE
Upgrade to JDK 17

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -14,11 +14,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: iot-benchmark
-      - name: Set java 8
+      - name: Set java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 17
       - name: run core unit tests
         run: |
           cd ${{ github.workspace }}/iot-benchmark

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        java_version: [ 8 ]
+        java_version: [ 17 ]
         release_db: [ iotdb-1.3,iotdb-2.0,influxdb,influxdb-2.0,timescaledb,timescaledb-cluster ]
     steps:
       # set java

--- a/.github/workflows/release_history_commit.yml
+++ b/.github/workflows/release_history_commit.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        java_version: [ 8 ]
+        java_version: [ 17 ]
     steps:
       # checkout iot-benchmark
       - name: Set the commit ID you want to release

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -14,6 +14,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: iot-benchmark
+      - name: Set java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
       - name: spotless-check
         run: |
           cd ${{ github.workspace }}/iot-benchmark

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Spotless runs automatically during `validate` phase. On JDK <= 11, spotless is s
 
 `.github/workflows/` runs on every push/PR to `master`:
 
-- **`core-test.yml`** — `mvn -B test -pl core` on JDK 8. Any new core unit test must pass here.
+- **`core-test.yml`** — `mvn -B test -pl core` on JDK 17. Any new core unit test must pass here.
 - **`spotless.yml`** — `mvn spotless:check`. Run `mvn spotless:apply` locally before pushing.
 
 `main.yml` is a release-artifact build (matrix over `iotdb-1.3`, `iotdb-2.0`, `influxdb`, `influxdb-2.0`, `timescaledb`, `timescaledb-cluster`) triggered on master pushes, not a PR gate.
@@ -115,7 +115,7 @@ Key parameters:
 
 ## Code Style
 
-- Java 8 source level
+- Java 17 source level
 - Google Java Format enforced by Spotless
 - Import order: `org.apache.iotdb`, default, `javax`, `java`, static
 - UNIX line endings

--- a/README-cn.md
+++ b/README-cn.md
@@ -1,7 +1,7 @@
 IoT Benchmark
 ---
 ![](https://img.shields.io/badge/platform-MacOS%20%7C%20Linux%20%7C%20Windows-yellow.svg)
-![](https://img.shields.io/badge/java--language-1.8-blue.svg)
+![](https://img.shields.io/badge/java--language-17-blue.svg)
 
 - [1. 概述](#1-概述)
 - [2. 支持的数据库类型](#2-支持的数据库类型)
@@ -52,7 +52,7 @@ IoT Benchmark 是用来评估时序数据库、实时数据库在工业物联网
 
 为了使用 IoT Benchmark，你需要拥有：
 
-1. Java 8
+1. Java 17
 2. Maven：不建议使用镜像源，国内可以使用阿里云镜像源。
 3. 合适版本的数据库
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 IoT Benchmark
 ---
 ![](https://img.shields.io/badge/platform-MacOS%20%7C%20Linux%20%7C%20Windows-yellow.svg)
-![](https://img.shields.io/badge/java--language-1.8-blue.svg)
+![](https://img.shields.io/badge/java--language-17-blue.svg)
 
 You can also read [中文版本](README-cn.md).
 
@@ -55,7 +55,7 @@ Currently supports the following databases, versions and connection methods:
 
 To use IoT Benchmark, you need:
 
-1. Java 8
+1. Java 17
 2. Maven: It is not recommended to use the mirror source. You can use the Alibaba Cloud mirror source in China.
 3. The appropriate version of the database
 

--- a/cnosdb/README.md
+++ b/cnosdb/README.md
@@ -6,7 +6,7 @@ This module uses IoT Benchmark to test CnosDB.
 
 Before running the benchmark, prepare:
 
-1. Java 8
+1. Java 17
 2. Maven 3.6+
 3. A running CnosDB instance reachable from the benchmark machine
 

--- a/cnosdb/pom.xml
+++ b/cnosdb/pom.xml
@@ -84,7 +84,15 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><configuration><source>${compile.version}</source><target>${targetJavaVersion}</target></configuration></plugin>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${compile.version}</source>
+                    <target>${targetJavaVersion}</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/cnosdb/pom.xml
+++ b/cnosdb/pom.xml
@@ -85,14 +85,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${compile.version}</source>
-                    <target>${targetJavaVersion}</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/cnosdb/pom.xml
+++ b/cnosdb/pom.xml
@@ -84,7 +84,7 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><configuration><source>8</source><target>8</target></configuration></plugin>
+            </plugin><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><configuration><source>${compile.version}</source><target>${targetJavaVersion}</target></configuration></plugin>
         </plugins>
     </build>
 </project>

--- a/docs/DeveloperGuide-cn.md
+++ b/docs/DeveloperGuide-cn.md
@@ -324,7 +324,7 @@ This module uses IoT Benchmark to test YourDB.
 
 Before running the benchmark, prepare:
 
-1. Java 8
+1. Java 17
 2. Maven 3.6+
 3. A running YourDB instance reachable from the benchmark machine
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -324,7 +324,7 @@ This module uses IoT Benchmark to test YourDB.
 
 Before running the benchmark, prepare:
 
-1. Java 8
+1. Java 17
 2. Maven 3.6+
 3. A running YourDB instance reachable from the benchmark machine
 

--- a/docs/DifferentTestModeConfig-cn.md
+++ b/docs/DifferentTestModeConfig-cn.md
@@ -1,5 +1,5 @@
 ![](https://img.shields.io/badge/platform-MacOS%20%7C%20Linux%20%7C%20Windows-yellow.svg)
-![](https://img.shields.io/badge/java--language-1.8-blue.svg)
+![](https://img.shields.io/badge/java--language-17-blue.svg)
 
 ** This document shows the specific configuration and execution of several test scenarios given in README.md **
 ** 该文档展示了README.md中给出的几种测试场景的具体配置以及具体执行情况 **

--- a/docs/DifferentTestModeConfig.md
+++ b/docs/DifferentTestModeConfig.md
@@ -1,5 +1,5 @@
 ![](https://img.shields.io/badge/platform-MacOS%20%7C%20Linux%20%7C%20Windows-yellow.svg)
-![](https://img.shields.io/badge/java--language-1.8-blue.svg)
+![](https://img.shields.io/badge/java--language-17-blue.svg)
 
 ** This document shows the specific configuration and execution of several test scenarios given in README.md **
 

--- a/influxdb/README.md
+++ b/influxdb/README.md
@@ -6,7 +6,7 @@ This module uses IoT Benchmark to test InfluxDB 1.x.
 
 Prepare the following environment before running the benchmark:
 
-1. Java 8
+1. Java 17
 2. Maven 3.6+
 3. A running InfluxDB 1.x instance reachable from the benchmark machine
 

--- a/kairosdb/README.md
+++ b/kairosdb/README.md
@@ -6,7 +6,7 @@ This module uses IoT Benchmark to test KairosDB.
 
 Before running the benchmark, prepare:
 
-1. Java 8
+1. Java 17
 2. Maven 3.6+
 3. A running KairosDB instance reachable from the benchmark machine
 

--- a/mssqlserver/README.md
+++ b/mssqlserver/README.md
@@ -7,7 +7,7 @@ Before running the benchmark, prepare:
 
 1. Microsoft SQL Server `2016 SP2` Standard Edition or a compatible newer version
 2. A management client such as Microsoft SQL Server Management Studio (SSMS) or `sqlcmd`
-3. Java 8
+3. Java 17
 4. Maven 3.6+
 
 Notes specific to Microsoft SQL Server:

--- a/mssqlserver/pom.xml
+++ b/mssqlserver/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>6.2.0.jre8</version>
+            <version>13.4.0.jre11</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/mssqlserver/pom.xml
+++ b/mssqlserver/pom.xml
@@ -14,8 +14,8 @@
     <name>Benchmark MS SQL Server</name>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>${compile.version}</maven.compiler.source>
+        <maven.compiler.target>${targetJavaVersion}</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/opentsdb/README.md
+++ b/opentsdb/README.md
@@ -14,7 +14,7 @@ OpenTSDB should be installed in a Linux system. The following prerequisites shou
 
 For the benchmark side, also prepare:
 
-- Java 8
+- Java 17
 - Maven 3.6+
 
 ### Installation of the prerequisites

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
     </modules>
 
     <properties>
-        <compile.version>1.8</compile.version>
-        <targetJavaVersion>1.8</targetJavaVersion>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <compile.version>17</compile.version>
+        <targetJavaVersion>17</targetJavaVersion>
+        <maven.compiler.source>${compile.version}</maven.compiler.source>
         <maven.compiler.target>${targetJavaVersion}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.13.1</junit.version>
@@ -64,10 +64,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.11.0</version>
                     <configuration>
                         <source>${compile.version}</source>
-                        <target>${compile.version}</target>
+                        <target>${targetJavaVersion}</target>
                         <encoding>UTF-8</encoding>
                     </configuration>
                 </plugin>

--- a/questdb/README.md
+++ b/questdb/README.md
@@ -9,7 +9,7 @@ Benchmark Questdb
 Before running the benchmark, prepare:
 
 1. A running QuestDB instance
-2. Java 8
+2. Java 17
 3. Maven 3.6+
 
 QuestDB-specific notes:

--- a/sqlite/README.md
+++ b/sqlite/README.md
@@ -5,7 +5,7 @@ Benchmark SQLite
 
 Before running the benchmark, prepare:
 
-1. Java 8
+1. Java 17
 2. Maven 3.6+
 3. A writable local directory for the benchmark output files
 

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -14,8 +14,8 @@
     <name>Benchmark SQLite</name>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>${compile.version}</maven.compiler.source>
+        <maven.compiler.target>${targetJavaVersion}</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/tdengine-3.0/README.md
+++ b/tdengine-3.0/README.md
@@ -5,7 +5,7 @@
 Before running the benchmark, prepare:
 
 1. A running TDengine 3.x server
-2. Java 8
+2. Java 17
 3. Maven 3.6+
 4. A benchmark machine that can access the TDengine server
 

--- a/tdengine/README.md
+++ b/tdengine/README.md
@@ -5,7 +5,7 @@
 Before running the benchmark, prepare:
 
 1. A running TDengine server
-2. Java 8
+2. Java 17
 3. Maven 3.6+
 4. A benchmark machine that can access the TDengine server
 

--- a/timescaledb-cluster/README.md
+++ b/timescaledb-cluster/README.md
@@ -6,7 +6,7 @@ Benchmark for timescaleDB
 Before running the benchmark, prepare:
 
 1. A running TimescaleDB multi-node or cluster deployment
-2. Java 8
+2. Java 17
 3. Maven 3.6+
 
 The sample configuration in this directory uses:

--- a/timescaledb/README.md
+++ b/timescaledb/README.md
@@ -6,7 +6,7 @@ Benchmark for timescaleDB
 Before running the benchmark, prepare:
 
 1. A running TimescaleDB instance
-2. Java 8
+2. Java 17
 3. Maven 3.6+
 
 ## 2. Database setup

--- a/verification/pom.xml
+++ b/verification/pom.xml
@@ -14,8 +14,8 @@
     <name>Benchmark verification</name>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>${compile.version}</maven.compiler.source>
+        <maven.compiler.target>${targetJavaVersion}</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/victoriametrics/README.md
+++ b/victoriametrics/README.md
@@ -6,7 +6,7 @@ Benchmark victoriaMetrics
 Before running the benchmark, prepare:
 
 1. A running VictoriaMetrics instance
-2. Java 8
+2. Java 17
 3. Maven 3.6+
 
 ## 2. Database setup


### PR DESCRIPTION
## Summary

- Upgrade the Maven compiler configuration from Java 8 to Java 17.
- Update modules that explicitly overrode compiler source/target settings so they inherit the Java 17 properties.
- Update GitHub Actions workflows to run on JDK 17, including an explicit setup step for spotless checks.
- Update README and related documentation to describe Java 17 requirements.

## Impact

Builds, release artifacts, and project documentation now target JDK 17 consistently across local Maven builds and CI workflows.

## Validation

- `mvn -B test -pl core`
- `mvn -B -DskipTests package`
- `mvn -B -DskipTests compile -pl core`
- `git diff --check`
