### PR TITLE
Update IoTDB 2.0 client SSL config

### DIFF
--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -87,6 +87,11 @@
 # SSL 配置
 # TRUST_STORE_PATH=
 # TRUST_STORE_PWD=
+# 双向 SSL 认证时配置客户端 keystore。
+# KEY_STORE_PATH=
+# KEY_STORE_PWD=
+# SSL 协议，默认 TLS。
+# SSL_PROTOCOL=TLS
 
 ################ Benchmark：集群模式 ####################
 # 是否在Benchmark集群模式下运行

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
@@ -316,6 +316,9 @@ public class Config {
 
   private String TRUST_STORE_PATH = "";
   private String TRUST_STORE_PWD = "";
+  private String KEY_STORE_PATH = "";
+  private String KEY_STORE_PWD = "";
+  private String SSL_PROTOCOL = "TLS";
 
   /** the ratio of use debug */
   private double IOTDB_USE_DEBUG_RATIO = 0.01;
@@ -1315,6 +1318,30 @@ public class Config {
     return TRUST_STORE_PWD;
   }
 
+  public void setKEY_STORE_PATH(String KEY_STORE_PATH) {
+    this.KEY_STORE_PATH = KEY_STORE_PATH;
+  }
+
+  public String getKEY_STORE_PATH() {
+    return KEY_STORE_PATH;
+  }
+
+  public void setKEY_STORE_PWD(String KEY_STORE_PWD) {
+    this.KEY_STORE_PWD = KEY_STORE_PWD;
+  }
+
+  public String getKEY_STORE_PWD() {
+    return KEY_STORE_PWD;
+  }
+
+  public void setSSL_PROTOCOL(String SSL_PROTOCOL) {
+    this.SSL_PROTOCOL = SSL_PROTOCOL;
+  }
+
+  public String getSSL_PROTOCOL() {
+    return SSL_PROTOCOL;
+  }
+
   public int getHTTP_CLIENT_POOL_SIZE() {
     return HTTP_CLIENT_POOL_SIZE;
   }
@@ -2201,6 +2228,12 @@ public class Config {
         "Extern Param", "ENABLE_THRIFT_COMPRESSION", this.ENABLE_THRIFT_COMPRESSION);
     configProperties.addProperty(
         "Extern Param", "ENABLE_IoTDB_RPC_COMPRESSION", this.ENABLE_IOTDB_RPC_COMPRESSION);
+    configProperties.addProperty("Extern Param", "USE_SSL", this.USE_SSL);
+    configProperties.addProperty("Extern Param", "TRUST_STORE_PATH", this.TRUST_STORE_PATH);
+    configProperties.addProperty("Extern Param", "TRUST_STORE_PWD", this.TRUST_STORE_PWD);
+    configProperties.addProperty("Extern Param", "KEY_STORE_PATH", this.KEY_STORE_PATH);
+    configProperties.addProperty("Extern Param", "KEY_STORE_PWD", this.KEY_STORE_PWD);
+    configProperties.addProperty("Extern Param", "SSL_PROTOCOL", this.SSL_PROTOCOL);
     configProperties.addProperty(
         "Extern Param", "WRITE_OPERATION_TIMEOUT_MS", this.WRITE_OPERATION_TIMEOUT_MS);
     configProperties.addProperty(

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -396,6 +396,15 @@ public class ConfigDescriptor {
         config.setTRUST_STORE_PWD(
             properties.getProperty("TRUST_STORE_PWD", String.valueOf(config.getTRUST_STORE_PWD())));
 
+        config.setKEY_STORE_PATH(
+            properties.getProperty("KEY_STORE_PATH", String.valueOf(config.getKEY_STORE_PATH())));
+
+        config.setKEY_STORE_PWD(
+            properties.getProperty("KEY_STORE_PWD", String.valueOf(config.getKEY_STORE_PWD())));
+
+        config.setSSL_PROTOCOL(
+            properties.getProperty("SSL_PROTOCOL", String.valueOf(config.getSSL_PROTOCOL())));
+
         config.setCOMPRESSION(properties.getProperty("COMPRESSION", "NONE"));
         config.setTIMESCALEDB_REPLICATION_FACTOR(
             Integer.parseInt(

--- a/iotdb-2.0/pom.xml
+++ b/iotdb-2.0/pom.xml
@@ -47,7 +47,7 @@
   <properties>
     <!-- This was the last version to support Java 8 -->
     <logback.version>1.3.16</logback.version>
-    <iotdb.version>2.0.8</iotdb.version>
+    <iotdb.version>2.0.11-260701-SNAPSHOT</iotdb.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <gson.version>2.10.1</gson.version>
   </properties>

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/TableSessionManager.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/TableSessionManager.java
@@ -175,6 +175,13 @@ public class TableSessionManager extends SessionManager {
         .useSSL(config.isUSE_SSL())
         .trustStore(config.getTRUST_STORE_PATH())
         .trustStorePwd(config.getTRUST_STORE_PWD())
+        .keyStore(emptyToNull(config.getKEY_STORE_PATH()))
+        .keyStorePwd(emptyToNull(config.getKEY_STORE_PWD()))
+        .sslProtocol(config.getSSL_PROTOCOL())
         .build();
+  }
+
+  private String emptyToNull(String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
 }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/TreeSessionManager.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/TreeSessionManager.java
@@ -204,6 +204,13 @@ public class TreeSessionManager extends SessionManager {
         .useSSL(config.isUSE_SSL())
         .trustStore(config.getTRUST_STORE_PATH())
         .trustStorePwd(config.getTRUST_STORE_PWD())
+        .keyStore(emptyToNull(config.getKEY_STORE_PATH()))
+        .keyStorePwd(emptyToNull(config.getKEY_STORE_PWD()))
+        .sslProtocol(config.getSSL_PROTOCOL())
         .build();
+  }
+
+  private String emptyToNull(String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
 }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/SingleNodeJDBCConnection.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/SingleNodeJDBCConnection.java
@@ -63,9 +63,15 @@ public class SingleNodeJDBCConnection {
         info.setProperty("user", dbConfig.getUSERNAME());
         info.setProperty("password", dbConfig.getPASSWORD());
         if (config.isUSE_SSL()) {
-          info.setProperty("use_ssl", "true");
-          info.setProperty("trust_store", config.getTRUST_STORE_PATH());
-          info.setProperty("trust_store_pwd", config.getTRUST_STORE_PWD());
+          info.setProperty(org.apache.iotdb.jdbc.Config.USE_SSL, "true");
+          info.setProperty(org.apache.iotdb.jdbc.Config.TRUST_STORE, config.getTRUST_STORE_PATH());
+          info.setProperty(
+              org.apache.iotdb.jdbc.Config.TRUST_STORE_PWD, config.getTRUST_STORE_PWD());
+          if (!config.getKEY_STORE_PATH().isEmpty()) {
+            info.setProperty(org.apache.iotdb.jdbc.Config.KEY_STORE, config.getKEY_STORE_PATH());
+            info.setProperty(org.apache.iotdb.jdbc.Config.KEY_STORE_PWD, config.getKEY_STORE_PWD());
+          }
+          info.setProperty(org.apache.iotdb.jdbc.Config.SSL_PROTOCOL, config.getSSL_PROTOCOL());
         }
         connections[i] = DriverManager.getConnection(urls[i], info);
       } catch (Exception e) {


### PR DESCRIPTION
## Summary

- Upgrade the IoTDB 2.0 client dependencies to `2.0.11-260701-SNAPSHOT`.
- Add benchmark config entries for client keystore path/password and SSL protocol.
- Pass keystore and SSL protocol settings through IoTDB 2.0 JDBC, tree session, and table session clients.

## Impact

This allows IoTDB 2.0 benchmark runs to use the newer client snapshot and configure mutual SSL/client keystore parameters when SSL is enabled. Existing SSL truststore-only setups continue to work; empty keystore settings are not passed as client keystore paths.

## Validation

- `mvn -pl iotdb-2.0 -am -DskipTests compile`
- `mvn -pl iotdb-2.0 -DskipTests dependency:tree -Dincludes=org.apache.iotdb:iotdb-jdbc,org.apache.iotdb:iotdb-session`