### PR TITLE
Add configurable IoTDB Session Thrift max frame size

### DIFF
--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -196,6 +196,9 @@
 # 是否使用thrift压缩，需要在iotdb的配置文件iotdb-datanode.properties中设置dn_rpc_thrift_compression_enable=true
 # ENABLE_THRIFT_COMPRESSION=false
 
+# IoTDB Session客户端允许的最大Thrift帧大小，单位为字节。服务端dn_rpc_max_frame_size应不小于该值
+# IOTDB_THRIFT_MAX_FRAME_SIZE=67108864
+
 # 是否使用 IoTDB 额外的 RPC 压缩，需要使用 IoTDB 2.0.6 及以上版本
 # ENABLE_IOTDB_RPC_COMPRESSION=true
 

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/Config.java
@@ -278,6 +278,9 @@ public class Config {
   /** if enable the thrift compression */
   private boolean ENABLE_THRIFT_COMPRESSION = false;
 
+  /** Maximum Thrift frame size used by IoTDB Session clients, in bytes */
+  private int IOTDB_THRIFT_MAX_FRAME_SIZE = 64 * 1024 * 1024;
+
   /** if enable the iotdb-rpc compression */
   private boolean ENABLE_IOTDB_RPC_COMPRESSION = true;
 
@@ -1199,6 +1202,14 @@ public class Config {
 
   public void setENABLE_THRIFT_COMPRESSION(boolean ENABLE_THRIFT_COMPRESSION) {
     this.ENABLE_THRIFT_COMPRESSION = ENABLE_THRIFT_COMPRESSION;
+  }
+
+  public int getIOTDB_THRIFT_MAX_FRAME_SIZE() {
+    return IOTDB_THRIFT_MAX_FRAME_SIZE;
+  }
+
+  public void setIOTDB_THRIFT_MAX_FRAME_SIZE(int IOTDB_THRIFT_MAX_FRAME_SIZE) {
+    this.IOTDB_THRIFT_MAX_FRAME_SIZE = IOTDB_THRIFT_MAX_FRAME_SIZE;
   }
 
   public boolean isENABLE_IOTDB_RPC_COMPRESSION() {
@@ -2237,6 +2248,8 @@ public class Config {
 
     configProperties.addProperty(
         "Extern Param", "ENABLE_THRIFT_COMPRESSION", this.ENABLE_THRIFT_COMPRESSION);
+    configProperties.addProperty(
+        "Extern Param", "IOTDB_THRIFT_MAX_FRAME_SIZE", this.IOTDB_THRIFT_MAX_FRAME_SIZE);
     configProperties.addProperty(
         "Extern Param", "ENABLE_IoTDB_RPC_COMPRESSION", this.ENABLE_IOTDB_RPC_COMPRESSION);
     configProperties.addProperty("Extern Param", "USE_SSL", this.USE_SSL);

--- a/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptor.java
@@ -344,6 +344,10 @@ public class ConfigDescriptor {
             Boolean.parseBoolean(
                 properties.getProperty(
                     "ENABLE_THRIFT_COMPRESSION", config.isENABLE_THRIFT_COMPRESSION() + "")));
+        config.setIOTDB_THRIFT_MAX_FRAME_SIZE(
+            Integer.parseInt(
+                properties.getProperty(
+                    "IOTDB_THRIFT_MAX_FRAME_SIZE", config.getIOTDB_THRIFT_MAX_FRAME_SIZE() + "")));
         config.setENABLE_IOTDB_RPC_COMPRESSION(
             Boolean.parseBoolean(
                 properties.getProperty(
@@ -765,6 +769,10 @@ public class ConfigDescriptor {
     result &= checkDatabaseTableDeviceRelationship();
     result &= checkDeviceNumPerWrite();
     result &= checkTag();
+    if (config.getIOTDB_THRIFT_MAX_FRAME_SIZE() <= 0) {
+      LOGGER.error("IOTDB_THRIFT_MAX_FRAME_SIZE must be greater than 0");
+      result = false;
+    }
     if (!commonlyUseDB()) {
       if (config.isALIGN_BY_DEVICE()) {
         result = false;

--- a/core/src/test/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptorTest.java
+++ b/core/src/test/java/cn/edu/tsinghua/iot/benchmark/conf/ConfigDescriptorTest.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -37,6 +38,7 @@ public class ConfigDescriptorTest extends BenchmarkTestBase {
   private int originalDeviceNumber;
   private int originalSchemaClientNumber;
   private int originalDataClientNumber;
+  private int originalIoTDBThriftMaxFrameSize;
 
   @Before
   public void before() {
@@ -45,6 +47,7 @@ public class ConfigDescriptorTest extends BenchmarkTestBase {
     originalDeviceNumber = config.getDEVICE_NUMBER();
     originalSchemaClientNumber = config.getSCHEMA_CLIENT_NUMBER();
     originalDataClientNumber = config.getDATA_CLIENT_NUMBER();
+    originalIoTDBThriftMaxFrameSize = config.getIOTDB_THRIFT_MAX_FRAME_SIZE();
   }
 
   @After
@@ -55,6 +58,7 @@ public class ConfigDescriptorTest extends BenchmarkTestBase {
     config.setDEVICE_NUMBER(originalDeviceNumber);
     config.setSCHEMA_CLIENT_NUMBER(originalSchemaClientNumber);
     config.setDATA_CLIENT_NUMBER(originalDataClientNumber);
+    config.setIOTDB_THRIFT_MAX_FRAME_SIZE(originalIoTDBThriftMaxFrameSize);
   }
 
   /**
@@ -85,6 +89,16 @@ public class ConfigDescriptorTest extends BenchmarkTestBase {
     config.setDEVICE_NUMBER(50);
     assertFalse(
         "client-bind with device number < data client number must be rejected",
+        ConfigDescriptor.getInstance().checkConfig());
+  }
+
+  @Test
+  public void testIoTDBThriftMaxFrameSize() {
+    assertEquals(64 * 1024 * 1024, config.getIOTDB_THRIFT_MAX_FRAME_SIZE());
+
+    config.setIOTDB_THRIFT_MAX_FRAME_SIZE(0);
+    assertFalse(
+        "IoTDB Thrift max frame size must be positive",
         ConfigDescriptor.getInstance().checkConfig());
   }
 }

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/TableSessionManager.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/TableSessionManager.java
@@ -168,6 +168,7 @@ public class TableSessionManager extends SessionManager {
         .nodeUrls(hostUrls)
         .username(dbConfig.getUSERNAME())
         .password(dbConfig.getPASSWORD())
+        .thriftMaxFrameSize(config.getIOTDB_THRIFT_MAX_FRAME_SIZE())
         .enableCompaction(config.isENABLE_THRIFT_COMPRESSION())
         .enableCompression(config.isENABLE_IOTDB_RPC_COMPRESSION())
         .enableRedirection(true)

--- a/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/TreeSessionManager.java
+++ b/iotdb-2.0/src/main/java/cn/edu/tsinghua/iot/benchmark/iotdb200/DMLStrategy/TreeSessionManager.java
@@ -196,6 +196,7 @@ public class TreeSessionManager extends SessionManager {
         .nodeUrls(hostUrls)
         .username(dbConfig.getUSERNAME())
         .password(dbConfig.getPASSWORD())
+        .thriftMaxFrameSize(config.getIOTDB_THRIFT_MAX_FRAME_SIZE())
         .enableRedirection(true)
         .version(Version.V_1_0)
         .sqlDialect(config.getIoTDB_DIALECT_MODE().name())


### PR DESCRIPTION
## Summary

- add `IOTDB_THRIFT_MAX_FRAME_SIZE` with a default value of 64 MiB
- validate that the configured frame size is positive
- apply the value to both IoTDB 2.0 tree and table Session builders
- document the matching `dn_rpc_max_frame_size` server-side requirement

## Testing

- `mvn -pl core -Dtest=ConfigDescriptorTest test`
- `mvn -pl iotdb-2.0 -am -DskipTests compile`

Manual ingestion comparison with large Thrift frames:

- Before: 0 successful operations/points; failures increased from 5 operations / 60 points to 10 operations / 120 points; throughput remained 0.00 point/s.
- After: reached 428 successful operations / 5,136 points with 0 failed operations and 0 failed points; observed throughput was 8.50-9.51 point/s.